### PR TITLE
chore: replace UK references with US equivalents and add Claude commands

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -1,0 +1,7 @@
+Start the local dev environment: Colima, Supabase, and Expo web.
+
+1. Source `~/.zprofile` so Homebrew binaries are on PATH.
+2. Start Colima if it isn't already running (`colima status`).
+3. Start Supabase if it isn't already running (`supabase status`), using `npm run supabase:start`. Wait for it to finish.
+4. Start Expo web in the background using `npm run web`. Tail output until Metro is ready and the dev server URL is shown.
+5. Report the Supabase Studio URL (usually http://localhost:54323) and the Expo web URL (usually http://localhost:8081).

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,32 @@
+Pull the latest changes, commit staged/unstaged changes to a new branch, and open a pull request.
+
+1. Run `git status` and `git diff` in parallel to understand the current state of the working directory.
+2. If the working tree is clean (nothing to commit and no untracked relevant files), skip to step 5.
+3. If on `main` (or any protected branch), generate a short kebab-case branch name that describes the changes (e.g. `feat/us-locale-updates`, `fix/onboarding-phone-placeholder`). Use the diff and file names to infer the right prefix (`feat/`, `fix/`, `chore/`, `docs/`). Run `git checkout -b <generated-branch-name>`.
+4. Stage all modified tracked files (`git add -u`) plus any relevant untracked files. Write a concise conventional commit message based on the changes and commit them.
+5. Run `git pull origin main --rebase`. If there are rebase conflicts, report them and stop — do not attempt to resolve them automatically.
+6. Run `git push -u origin HEAD` to push the branch to remote.
+7. Check if the `gh` CLI is available (`gh --version`). If not, report that the GitHub CLI is not installed and provide the PR URL format instead: `https://github.com/<owner>/<repo>/compare/<branch>`.
+8. Check if a PR already exists for this branch (`gh pr view`). If yes, report its URL and open it with `gh pr view --web`. If no, create one:
+
+   ```
+   gh pr create --title "<title>" --body "$(cat <<'EOF'
+   ## Summary
+   - <bullet points describing changes>
+
+   ## Test plan
+   - [ ] Verify changes work as expected on simulator
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+
+9. Report the PR URL when done.
+
+Notes:
+
+- Never force-push.
+- Never skip pre-commit hooks (`--no-verify`).
+- If the user provides a title or description in their message, use that instead of auto-generating.
+- Prefer specific file staging over `git add -A` to avoid accidentally including `.env` or build artifacts.

--- a/.claude/commands/shutdown.md
+++ b/.claude/commands/shutdown.md
@@ -1,0 +1,7 @@
+Stop the local dev environment: Expo, Supabase, and Colima.
+
+1. Source `~/.zprofile` so Homebrew binaries are on PATH.
+2. Stop the Expo web process if it is running (find and kill the process on port 8081).
+3. Stop Supabase using `npm run supabase:stop`. Wait for it to finish.
+4. Stop Colima using `colima stop`.
+5. Report when each step is complete.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
     "expo-app-design@expo-plugins": true,
     "upgrading-expo@expo-plugins": true,
     "postgres-best-practices@supabase-agent-skills": true,
-    "expo-deployment@expo-plugins": true
+    "expo-deployment@expo-plugins": true,
+    "frontend-design@claude-plugins-official": true
   }
 }

--- a/app/(auth)/sms.tsx
+++ b/app/(auth)/sms.tsx
@@ -89,7 +89,7 @@ export default function SmsModal() {
               </Text>
             )}
             <Text style={{ fontSize: 13, color: '#888', marginTop: 4 }}>
-              US numbers are auto-detected. Include a country code (e.g. +44) for international.
+              US numbers are auto-detected. Include a country code for international numbers.
             </Text>
             <View style={{ marginTop: 8 }}>
               {phoneForm.formState.isSubmitting ? (

--- a/components/onboarding/ProfileStep.tsx
+++ b/components/onboarding/ProfileStep.tsx
@@ -158,7 +158,7 @@ export default function ProfileStep({ role, defaultPhoneNumber, onNext }: Props)
             render={({ field: { onChange, value } }) => (
               <TextInput
                 className="bg-white rounded-[12px] border-[1.5px] border-divider px-4 py-[14px] text-16 text-ink"
-                placeholder="+44 7700 000000"
+                placeholder="+1 555 000 0000"
                 placeholderTextColor={colors.inkGhost}
                 value={value}
                 onChangeText={onChange}

--- a/components/ui/DateInput.native.tsx
+++ b/components/ui/DateInput.native.tsx
@@ -11,7 +11,7 @@ type Props = {
 };
 
 function formatDate(date: Date) {
-  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+  return date.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' });
 }
 
 export default function DateInput({ value, onChange, style }: Props) {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,55 @@
+#!/bin/zsh
+set -e
+
+echo "==> Installing Homebrew..."
+if ! command -v brew &>/dev/null; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Add Homebrew to PATH for Apple Silicon
+  if [[ -f /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+  fi
+else
+  echo "   Homebrew already installed, skipping."
+fi
+
+echo "==> Installing Node.js (includes npm)..."
+if ! command -v node &>/dev/null; then
+  brew install node
+else
+  echo "   Node already installed: $(node -v)"
+fi
+
+echo "==> Installing Colima (Docker runtime)..."
+if ! command -v colima &>/dev/null; then
+  brew install colima docker
+  colima start
+else
+  echo "   Colima already installed, skipping."
+  if ! colima status 2>/dev/null | grep -q "running"; then
+    colima start
+  fi
+fi
+
+echo "==> Installing PostgreSQL client (psql)..."
+if ! command -v psql &>/dev/null; then
+  brew install libpq
+  brew link --force libpq
+else
+  echo "   psql already installed, skipping."
+fi
+
+echo "==> Installing Supabase CLI..."
+if ! command -v supabase &>/dev/null; then
+  brew install supabase/tap/supabase
+else
+  echo "   Supabase CLI already installed, skipping."
+fi
+
+echo "==> Installing project dependencies..."
+cd "$(dirname "$0")/.."
+npm install
+
+echo ""
+echo "Setup complete! Run the app with:"
+echo "  npm run web"


### PR DESCRIPTION
## Summary
- Replace UK phone placeholder (`+44 7700 000000`) with US format (`+1 555 000 0000`) in onboarding
- Remove `+44` example from SMS screen country code hint text
- Switch date formatting locale from `en-GB` to `en-US` (e.g. "March 6, 2026")
- Add `/dev`, `/pr`, `/shutdown` Claude command files for local dev workflow

## Test plan
- [ ] Go through onboarding — verify phone field shows `+1 555 000 0000` placeholder
- [ ] On login/SMS screen — verify hint text no longer mentions `+44`
- [ ] In onboarding date-of-birth picker — verify date displays as "March 6, 2026" format

🤖 Generated with [Claude Code](https://claude.com/claude-code)