### PR TITLE
feat: hide profile sections when dating status is Just Winging

### DIFF
--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -78,6 +78,8 @@ function ProfileScreenInner() {
 
   const form = useForm<OwnDatingProfile>({ defaultValues: datingProfile ?? undefined });
 
+  const dating_status = form.watch('dating_status');
+
   const handleRefresh = useCallback(async () => {
     const result = await refetch();
     if (result.data?.datingProfile) form.reset(result.data.datingProfile);
@@ -119,17 +121,24 @@ function ProfileScreenInner() {
         <IconSymbol name="chevron.right" size={13} color={colors.inkGhost} />
       </Pressable>
 
-      <TextTabBar
-        tabs={['About Me', 'Photos', 'Prompts']}
-        active={activeTab}
-        setActive={setActiveTab}
-      />
-
-      {activeTab === 0 && <AboutMeTab form={form} data={datingProfile} userId={userId} />}
-      {activeTab === 1 && (
-        <PhotosTab form={form} data={datingProfile} userId={userId} onRefresh={handleRefresh} />
+      {dating_status === 'winging' ? (
+        <AboutMeTab form={form} data={datingProfile} userId={userId} />
+      ) : (
+        <>
+          <TextTabBar
+            tabs={['About Me', 'Photos', 'Prompts']}
+            active={activeTab}
+            setActive={setActiveTab}
+          />
+          {activeTab === 0 && <AboutMeTab form={form} data={datingProfile} userId={userId} />}
+          {activeTab === 1 && (
+            <PhotosTab form={form} data={datingProfile} userId={userId} onRefresh={handleRefresh} />
+          )}
+          {activeTab === 2 && (
+            <PromptsTab form={form} data={datingProfile} onRefresh={handleRefresh} />
+          )}
+        </>
       )}
-      {activeTab === 2 && <PromptsTab form={form} data={datingProfile} onRefresh={handleRefresh} />}
     </SafeAreaView>
   );
 }

--- a/components/profile/AboutMeTab.tsx
+++ b/components/profile/AboutMeTab.tsx
@@ -110,47 +110,54 @@ export function AboutMeTab({ form, data, userId }: Props) {
         </View>
       )}
 
-      <Text className="text-12 font-bold text-ink-dim uppercase tracking-[0.6px] mt-5 mb-2">
-        Details
-      </Text>
-      <View className="bg-white rounded-14 overflow-hidden">
-        {detailRows.map((row, i) => (
-          <View
-            key={row.label}
-            className="flex-row items-center justify-between px-[14px] py-[13px]"
-            style={
-              i < detailRows.length - 1
-                ? { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.divider }
-                : undefined
-            }
-          >
-            <Text className="text-15 text-ink-mid">{row.label}</Text>
-            <Text className="text-15 font-medium text-ink">{row.value}</Text>
-          </View>
-        ))}
-      </View>
-
-      {data.bio ? (
+      {dating_status !== 'winging' && (
         <>
           <Text className="text-12 font-bold text-ink-dim uppercase tracking-[0.6px] mt-5 mb-2">
-            Bio
+            Details
           </Text>
-          <View className="bg-white rounded-14 overflow-hidden p-[14px]">
-            <Text className="text-15 text-ink leading-[22px]">{data.bio}</Text>
-          </View>
-        </>
-      ) : null}
-
-      {data.interests.length > 0 && (
-        <>
-          <Text className="text-12 font-bold text-ink-dim uppercase tracking-[0.6px] mt-5 mb-2">
-            Interests
-          </Text>
-          <View className="flex-row flex-wrap gap-2">
-            {data.interests.map((interest) => (
-              <Pill key={interest} label={interest} />
+          <View className="bg-white rounded-14 overflow-hidden">
+            {detailRows.map((row, i) => (
+              <View
+                key={row.label}
+                className="flex-row items-center justify-between px-[14px] py-[13px]"
+                style={
+                  i < detailRows.length - 1
+                    ? {
+                        borderBottomWidth: StyleSheet.hairlineWidth,
+                        borderBottomColor: colors.divider,
+                      }
+                    : undefined
+                }
+              >
+                <Text className="text-15 text-ink-mid">{row.label}</Text>
+                <Text className="text-15 font-medium text-ink">{row.value}</Text>
+              </View>
             ))}
           </View>
+
+          {data.bio ? (
+            <>
+              <Text className="text-12 font-bold text-ink-dim uppercase tracking-[0.6px] mt-5 mb-2">
+                Bio
+              </Text>
+              <View className="bg-white rounded-14 overflow-hidden p-[14px]">
+                <Text className="text-15 text-ink leading-[22px]">{data.bio}</Text>
+              </View>
+            </>
+          ) : null}
+
+          {data.interests.length > 0 && (
+            <>
+              <Text className="text-12 font-bold text-ink-dim uppercase tracking-[0.6px] mt-5 mb-2">
+                Interests
+              </Text>
+              <View className="flex-row flex-wrap gap-2">
+                {data.interests.map((interest) => (
+                  <Pill key={interest} label={interest} />
+                ))}
+              </View>
+            </>
+          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary
- When a dater's `dating_status` is `winging`, the profile screen hides the tab bar and only shows the About Me tab (without Details, Bio, and Interests sections)
- When not winging, the full tabbed experience (About Me / Photos / Prompts) is shown as before

## Test plan
- [ ] Set dating status to "Just Winging" — verify tab bar is hidden and only About Me renders (without Details/Bio/Interests)
- [ ] Set dating status to "open" or "break" — verify full tab bar and all sections appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)