### PR TITLE
fix: add chevron.left icon mapping for web/Android

### DIFF
--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -17,6 +17,7 @@ const MAPPING = {
   'house.fill': 'home',
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
+  'chevron.left': 'chevron-left',
   'chevron.right': 'chevron-right',
 } as IconMapping;
 


### PR DESCRIPTION
## Summary
- Adds `chevron.left` → `chevron-left` mapping in the `IconSymbol` web/Android fallback so the back arrow renders on non-iOS platforms instead of being invisible

## Test plan
- [ ] Open wingpeople screen on iOS — purple back arrow works as before
- [ ] Open on web (`npm run web`) — back arrow now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)