### PR TITLE
feat: remove DaterCallout from wingswipe and seed wingpeople fixtures

### DIFF
--- a/app/(tabs)/profile/wingpeople/wingswipe.tsx
+++ b/app/(tabs)/profile/wingpeople/wingswipe.tsx
@@ -18,23 +18,6 @@ import { cardButtonShadow } from '@/lib/styles';
 
 const PAGE_SIZE = 20;
 
-// ── DaterCallout ──────────────────────────────────────────────────────────────
-
-function DaterCallout({ name, interests }: { name: string; interests: string[] }) {
-  return (
-    <View className="bg-accent-muted rounded-xl p-[14px] mb-4 gap-[10px]">
-      <Text className="text-sm font-semibold text-accent">You think {name} would like this?</Text>
-      {interests.length > 0 && (
-        <View className="flex-row flex-wrap gap-2">
-          {interests.map((interest) => (
-            <Pill key={interest} label={interest} />
-          ))}
-        </View>
-      )}
-    </View>
-  );
-}
-
 // ── WingCardView ──────────────────────────────────────────────────────────────
 
 type WingCardViewProps = {
@@ -46,10 +29,9 @@ type WingCardViewProps = {
     bio: string | null;
     first_photo: string | null;
   };
-  callout: React.ReactNode;
 };
 
-function WingCardView({ card, callout }: WingCardViewProps) {
+function WingCardView({ card }: WingCardViewProps) {
   return (
     <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
       <PhotoRect uri={card.first_photo} ratio={4 / 5} />
@@ -58,7 +40,6 @@ function WingCardView({ card, callout }: WingCardViewProps) {
           {card.chosen_name}, {card.age}
         </Text>
         <Text className="text-sm text-fg-muted mt-1 mb-3">{card.city}</Text>
-        {callout}
         {card.interests.length > 0 && (
           <View className="flex-row flex-wrap gap-2 mb-4">
             {card.interests.map((interest) => (
@@ -158,8 +139,6 @@ function WingSwipeContent() {
   const card = pool[index] ?? null;
 
   const daterName = daterContext?.chosen_name ?? '';
-  const daterInterests =
-    (daterContext?.dating_profiles as { interests: string[] } | null)?.interests ?? [];
   const firstName = daterName.split(' ')[0] || daterName;
 
   const [noteVisible, setNoteVisible] = useState(false);
@@ -179,10 +158,7 @@ function WingSwipeContent() {
 
       <View className="flex-1">
         {card != null ? (
-          <WingCardView
-            card={card}
-            callout={<DaterCallout name={firstName || 'them'} interests={daterInterests} />}
-          />
+          <WingCardView card={card} />
         ) : (
           <EmptyState daterName={firstName || 'them'} />
         )}
@@ -200,7 +176,9 @@ function WingSwipeContent() {
           <Pressable
             className="w-16 h-16 rounded-[32px] justify-center items-center bg-accent"
             style={cardButtonShadow}
-            onPress={() => setNoteVisible(true)}
+            onPress={() => suggest(null)}
+            onLongPress={() => setNoteVisible(true)}
+            delayLongPress={400}
           >
             <Text className="text-2xl text-white">♥</Text>
           </Pressable>

--- a/scripts/seed-local.ts
+++ b/scripts/seed-local.ts
@@ -474,6 +474,123 @@ async function seedDecisions(targetId: string, gender: 'Male' | 'Female'): Promi
   console.log(`  ${actorIds.length} ${gender} seed users → liked dev user`);
 }
 
+// ── Wingpeople seed ───────────────────────────────────────────────────────────
+
+// Three sample wingpeople who are actively winging for the dev user.
+const SAMPLE_WINGERS = [
+  { first: 'Alex', last: 'Chen', gender: 'Male' as const, phone: '+15550010001' },
+  { first: 'Jordan', last: 'Kim', gender: 'Female' as const, phone: '+15550010002' },
+  { first: 'Sam', last: 'Rivera', gender: 'Male' as const, phone: '+15550010003' },
+];
+
+// Two seed daters (by email) that the dev user will wing for.
+const WINGING_FOR_EMAILS = [
+  'seed.emma.sullivan@seed.orbit.test',
+  'seed.liam.murphy@seed.orbit.test',
+];
+
+async function ensureWingerProfile(
+  first: string,
+  last: string,
+  gender: 'Male' | 'Female',
+  phone: string
+): Promise<string> {
+  const email = `winger.${first.toLowerCase()}.${last.toLowerCase()}@seed.orbit.test`;
+
+  const { data: listData } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+  const existing = listData?.users.find((u) => u.email === email);
+  if (existing) {
+    console.log(`  winger ${first} ${last} already exists, skipping`);
+    return existing.id;
+  }
+
+  const { data: authData, error: authError } = await supabase.auth.admin.createUser({
+    email,
+    password: 'Orbit123!',
+    email_confirm: true,
+  });
+  if (authError) throw new Error(`winger ${first} auth error: ${authError.message}`);
+
+  const userId = authData.user.id;
+
+  const { error: profileError } = await supabase
+    .from('profiles')
+    .update({
+      chosen_name: first,
+      last_name: last,
+      gender,
+      date_of_birth: randomDob(22, 35),
+      role: 'winger',
+      phone_number: phone,
+    })
+    .eq('id', userId);
+  if (profileError) throw new Error(`winger ${first} profile error: ${profileError.message}`);
+
+  console.log(`  winger ${first} ${last} created (${userId})`);
+  return userId;
+}
+
+async function seedWingpeopleContacts(devUserId: string): Promise<void> {
+  // 1. Create winger profiles and link them as active wingpeople of the dev user.
+  for (const w of SAMPLE_WINGERS) {
+    const wingerId = await ensureWingerProfile(w.first, w.last, w.gender, w.phone);
+
+    const { data: existing } = await supabase
+      .from('contacts')
+      .select('id')
+      .eq('user_id', devUserId)
+      .eq('winger_id', wingerId)
+      .maybeSingle();
+
+    if (!existing) {
+      const { error } = await supabase.from('contacts').insert({
+        user_id: devUserId,
+        winger_id: wingerId,
+        phone_number: w.phone,
+        wingperson_status: 'active',
+      });
+      if (error) throw new Error(`contact for winger ${w.first} error: ${error.message}`);
+    }
+  }
+
+  // 2. Find the two seed daters and create contacts with dev user as their winger.
+  const { data: listData } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+  for (const email of WINGING_FOR_EMAILS) {
+    const dater = listData?.users.find((u) => u.email === email);
+    if (!dater) {
+      console.log(`  dater ${email} not found — skipping`);
+      continue;
+    }
+
+    const { data: daterProfile } = await supabase
+      .from('profiles')
+      .select('phone_number')
+      .eq('id', dater.id)
+      .single();
+
+    const phone = daterProfile?.phone_number ?? `+1555999${WINGING_FOR_EMAILS.indexOf(email)}`;
+
+    const { data: existing } = await supabase
+      .from('contacts')
+      .select('id')
+      .eq('user_id', dater.id)
+      .eq('winger_id', devUserId)
+      .maybeSingle();
+
+    if (!existing) {
+      const { error } = await supabase.from('contacts').insert({
+        user_id: dater.id,
+        winger_id: devUserId,
+        phone_number: phone,
+        wingperson_status: 'active',
+      });
+      if (error) throw new Error(`contact winging-for ${email} error: ${error.message}`);
+    }
+
+    console.log(`  dev user is now winging for ${email}`);
+  }
+}
+
 async function main(): Promise<void> {
   console.log('Setting up local dev database…\n');
 
@@ -499,6 +616,9 @@ async function main(): Promise<void> {
   console.log('\nSeeding decisions (all seed users like the dev user)…');
   await seedDecisions(devUserId, 'Female'); // 25 women like dev user
   await seedDecisions(devUserId, 'Male'); // 25 men like dev user
+
+  console.log('\nSeeding wingpeople relationships…');
+  await seedWingpeopleContacts(devUserId);
 
   console.log('\nDone. Local DB is ready. Sign in as dev@local.test / devpassword');
 }


### PR DESCRIPTION
## Summary
- Remove the "You think X would like this?" callout banner from the wing swipe card view
- Wire ♥ button to immediately suggest (no note modal required); long-press on ♥ still opens the note modal for optional notes
- Add `seedWingpeopleContacts` to `seed-local.ts`: creates 3 sample winger profiles (Alex Chen, Jordan Kim, Sam Rivera) as active wingpeople for the dev user, and links the dev user as active winger for Emma Sullivan and Liam Murphy

## Test plan
- [ ] Open wingswipe screen — card shows full profile with no callout banner
- [ ] Tap ♥ — suggestion is recorded and next card appears immediately
- [ ] Long-press ♥ — note modal opens; send with or without note advances the card
- [ ] Run `npm run db:fixtures` — wingpeople relationships are seeded; wingpeople screen shows all three sections populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)