### PR TITLE
feat: profile pictures visible only to active wingpeople

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -99,7 +99,7 @@ function WingNoteSection({ card }: { card: DiscoverCard }) {
   return (
     <View className="bg-accent-muted rounded-xl p-3 mb-4 gap-[6px]">
       <View className="flex-row items-center gap-2">
-        <WingStack initials={[initial]} />
+        <WingStack items={[{ initials: initial }]} />
         <Text className="text-sm font-semibold text-fg flex-1">
           {card.suggester_name} thinks you{"'"}d get along
         </Text>

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -119,7 +119,7 @@ function SheetBody({ match, currentUserId }: { match: MatchRow; currentUserId: s
       {wingNote?.note != null && (
         <View className="mx-5 mt-4 bg-accent-muted rounded-xl p-[14px]">
           <View className="flex-row items-center gap-2 mb-[6px]">
-            <WingStack initials={[getInitials(wingNote.winger?.chosen_name)]} />
+            <WingStack items={[{ initials: getInitials(wingNote.winger?.chosen_name) }]} />
             <Text className="text-sm font-semibold text-accent">
               {wingNote.winger?.chosen_name ?? 'Your wing'} introduced you
             </Text>

--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -3,8 +3,6 @@ import { StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { toast } from 'sonner-native';
 import { useForm } from 'react-hook-form';
-import * as ImagePicker from 'expo-image-picker';
-import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { colors } from '@/constants/theme';
@@ -13,7 +11,7 @@ import { useProfileData, updateDatingProfile } from '@/queries/profiles';
 import type { OwnDatingProfile } from '@/queries/profiles';
 import { useMyWingpeople } from '@/queries/contacts';
 import { supabase } from '@/lib/supabase';
-import { uploadAvatar } from '@/queries/photos';
+import { pickAndResizePhoto, uploadAvatar } from '@/queries/photos';
 
 import { View, Text, Pressable, SafeAreaView } from '@/lib/tw';
 import { LargeHeader } from '@/components/ui/LargeHeader';
@@ -86,22 +84,11 @@ function AvatarPicker({ name, avatarUrl, size, userId }: AvatarPickerProps) {
   const [uploading, setUploading] = useState(false);
 
   const handlePick = async () => {
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ['images'],
-      allowsEditing: true,
-      aspect: [1, 1],
-      quality: 0.9,
-    });
-    if (result.canceled) return;
+    const uri = await pickAndResizePhoto({ width: 400, aspect: [1, 1] });
+    if (!uri) return;
 
     setUploading(true);
-    const asset = result.assets[0];
-    const manipulated = await ImageManipulator.manipulate(asset.uri)
-      .resize({ width: 400 })
-      .renderAsync();
-    const file = await manipulated.saveAsync({ format: SaveFormat.JPEG, compress: 0.8 });
-
-    const { error } = await uploadAvatar(userId, file.uri);
+    const { error } = await uploadAvatar(userId, uri);
     setUploading(false);
     if (error) {
       toast.error("Couldn't upload photo. Try again.");

--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -3,7 +3,8 @@ import { StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { toast } from 'sonner-native';
 import { useForm } from 'react-hook-form';
-
+import * as ImagePicker from 'expo-image-picker';
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { colors } from '@/constants/theme';
@@ -12,6 +13,7 @@ import { useProfileData, updateDatingProfile } from '@/queries/profiles';
 import type { OwnDatingProfile } from '@/queries/profiles';
 import { useMyWingpeople } from '@/queries/contacts';
 import { supabase } from '@/lib/supabase';
+import { uploadAvatar } from '@/queries/photos';
 
 import { View, Text, Pressable, SafeAreaView } from '@/lib/tw';
 import { LargeHeader } from '@/components/ui/LargeHeader';
@@ -70,13 +72,81 @@ function ProfileBanner({
   );
 }
 
+// ── Tappable avatar (shared by dater + winger) ────────────────────────────────
+
+type AvatarPickerProps = {
+  name: string | null;
+  avatarUrl: string | null;
+  size: number;
+  userId: string;
+};
+
+function AvatarPicker({ name, avatarUrl, size, userId }: AvatarPickerProps) {
+  const queryClient = useQueryClient();
+  const [uploading, setUploading] = useState(false);
+
+  const handlePick = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.9,
+    });
+    if (result.canceled) return;
+
+    setUploading(true);
+    const asset = result.assets[0];
+    const manipulated = await ImageManipulator.manipulate(asset.uri)
+      .resize({ width: 400 })
+      .renderAsync();
+    const file = await manipulated.saveAsync({ format: SaveFormat.JPEG, compress: 0.8 });
+
+    const { error } = await uploadAvatar(userId, file.uri);
+    setUploading(false);
+    if (error) {
+      toast.error("Couldn't upload photo. Try again.");
+      return;
+    }
+    queryClient.invalidateQueries({ queryKey: ['profile', userId] });
+  };
+
+  return (
+    <Pressable onPress={handlePick} className="relative" style={{ width: size, height: size }}>
+      <FaceAvatar initials={getInitials(name)} size={size} photoUri={avatarUrl} />
+      {uploading ? (
+        <View
+          className="absolute inset-0 items-center justify-center rounded-full bg-black/40"
+          style={{ borderRadius: size / 2 }}
+        >
+          <IconSymbol name="arrow.clockwise" size={size * 0.3} color="white" />
+        </View>
+      ) : (
+        <View
+          className="absolute bottom-0 right-0 items-center justify-center bg-white rounded-full"
+          style={{ width: size * 0.32, height: size * 0.32, borderRadius: (size * 0.32) / 2 }}
+        >
+          <IconSymbol name="camera.fill" size={size * 0.17} color={colors.purple} />
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
 // ── Winger view (shared by role=winger and dating_status=winging) ─────────────
 
-function WingerView({ name }: { name: string | null }) {
+function WingerView({
+  name,
+  userId,
+  avatarUrl,
+}: {
+  name: string | null;
+  userId: string;
+  avatarUrl: string | null;
+}) {
   const router = useRouter();
   return (
     <View className="flex-1 items-center justify-center p-10">
-      <FaceAvatar initials={getInitials(name)} size={72} />
+      <AvatarPicker name={name} avatarUrl={avatarUrl} size={72} userId={userId} />
       <Text className="text-2xl font-bold text-fg mt-4 font-serif">{name ?? 'Winger'}</Text>
       <Text className="text-sm text-fg-muted mt-1">Winger</Text>
       <View className="mt-8 w-full">
@@ -134,7 +204,11 @@ function ProfileScreenInner() {
           sub="Set up a dater profile and start swiping."
           onPress={handleSwitchToDater}
         />
-        <WingerView name={profile.chosen_name} />
+        <WingerView
+          name={profile.chosen_name}
+          userId={userId}
+          avatarUrl={profile.avatar_url ?? null}
+        />
       </SafeAreaView>
     );
   }
@@ -160,38 +234,55 @@ function ProfileScreenInner() {
           sub="Tap here to create a dating profile."
           onPress={handleResumeDating}
         />
-        <WingerView name={profile?.chosen_name ?? null} />
+        <WingerView
+          name={profile?.chosen_name ?? null}
+          userId={userId}
+          avatarUrl={profile?.avatar_url ?? null}
+        />
       </SafeAreaView>
     );
   }
 
   // ── Dater view ────────────────────────────────────────────────────────────
-  const wingInitials = wingpeople.map((w) => getInitials((w as any).winger?.chosen_name));
+  const wingItems = wingpeople.map((w) => ({
+    initials: getInitials((w as any).winger?.chosen_name),
+    photoUri: (w as any).winger?.avatar_url ?? null,
+  }));
 
   return (
     <SafeAreaView className="flex-1 bg-page" edges={['top']}>
       <LargeHeader title="My Profile" right={<LogOutButton />} />
 
-      {/* Wingpeople row */}
-      <Pressable
-        className="flex-row items-center px-5 py-[10px] gap-[10px]"
+      {/* Avatar + wingpeople row */}
+      <View
+        className="flex-row items-center px-5 py-[10px] gap-3"
         style={{ borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.divider }}
-        onPress={() => router.push('/(tabs)/profile/wingpeople' as any)}
       >
-        {wingInitials.length > 0 ? (
-          <>
-            <WingStack initials={wingInitials} size={30} />
-            <Text className="flex-1 text-sm font-semibold text-fg">
-              {wingpeople.length} wingperson{wingpeople.length !== 1 ? 'e' : ''}
+        <AvatarPicker
+          name={profile?.chosen_name ?? null}
+          avatarUrl={profile?.avatar_url ?? null}
+          size={44}
+          userId={userId}
+        />
+        <Pressable
+          className="flex-1 flex-row items-center gap-[10px]"
+          onPress={() => router.push('/(tabs)/profile/wingpeople' as any)}
+        >
+          {wingItems.length > 0 ? (
+            <>
+              <WingStack items={wingItems} size={30} />
+              <Text className="flex-1 text-sm font-semibold text-fg">
+                {wingpeople.length} wingperson{wingpeople.length !== 1 ? 'e' : ''}
+              </Text>
+            </>
+          ) : (
+            <Text className="flex-1 text-sm text-fg-muted">
+              No wingpeople yet — tap to invite one
             </Text>
-          </>
-        ) : (
-          <Text className="flex-1 text-sm text-fg-muted">
-            No wingpeople yet — tap to invite one
-          </Text>
-        )}
-        <IconSymbol name="chevron.right" size={13} color={colors.inkGhost} />
-      </Pressable>
+          )}
+          <IconSymbol name="chevron.right" size={13} color={colors.inkGhost} />
+        </Pressable>
+      </View>
 
       <TextTabBar
         tabs={['About Me', 'Photos', 'Prompts']}

--- a/app/(tabs)/profile/wingpeople/index.tsx
+++ b/app/(tabs)/profile/wingpeople/index.tsx
@@ -141,7 +141,11 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
         </Text>
       ) : (
         wingpeople.map((w) => {
-          const winger = (w as any).winger as { id: string; chosen_name: string | null } | null;
+          const winger = (w as any).winger as {
+            id: string;
+            chosen_name: string | null;
+            avatar_url: string | null;
+          } | null;
           const name = winger?.chosen_name ?? 'Unknown';
           const count = weeklyCounts[w.id] ?? 0;
           return (
@@ -155,7 +159,7 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
               onLongPress={() => handleRemove(w.id)}
               delayLongPress={500}
             >
-              <FaceAvatar initials={getInitials(name)} size={40} />
+              <FaceAvatar initials={getInitials(name)} size={40} photoUri={winger?.avatar_url} />
               <View className="flex-1">
                 <Text className="text-sm font-semibold text-fg">{name}</Text>
                 <Text className="text-xs text-fg-muted mt-0.5">
@@ -248,7 +252,11 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
         </Text>
       ) : (
         wingingFor.map((wf) => {
-          const dater = (wf as any).dater as { id: string; chosen_name: string | null } | null;
+          const dater = (wf as any).dater as {
+            id: string;
+            chosen_name: string | null;
+            avatar_url: string | null;
+          } | null;
           const name = dater?.chosen_name ?? 'Unknown';
           const firstName = name.split(' ')[0];
           return (
@@ -260,7 +268,7 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
                 borderBottomColor: colors.divider,
               }}
             >
-              <FaceAvatar initials={getInitials(name)} size={40} />
+              <FaceAvatar initials={getInitials(name)} size={40} photoUri={dater?.avatar_url} />
               <Text className="flex-1 text-sm font-semibold text-fg">{name}</Text>
               <Pressable
                 className="px-[14px] py-2 rounded-full bg-accent-muted"

--- a/components/onboarding/PhotosStep.tsx
+++ b/components/onboarding/PhotosStep.tsx
@@ -2,10 +2,14 @@ import { useState, useEffect } from 'react';
 import { Alert, ActivityIndicator, Dimensions } from 'react-native';
 import { View, Text, SafeAreaView, Pressable } from '@/lib/tw';
 import { Image } from 'expo-image';
-import * as ImagePicker from 'expo-image-picker';
-import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import { createDatingProfile, getOwnDatingProfile } from '@/queries/profiles';
-import { uploadPhoto, insertPhoto, deleteOwnPhoto, getPhotoUrl } from '@/queries/photos';
+import {
+  pickAndResizePhoto,
+  uploadPhoto,
+  insertPhoto,
+  deleteOwnPhoto,
+  getPhotoUrl,
+} from '@/queries/photos';
 import { colors } from '@/constants/theme';
 import { toast } from 'sonner-native';
 import { cn } from '@/lib/cn';
@@ -73,28 +77,12 @@ export default function PhotosStep({ userId, dpId: initialDpId, onDpCreated, onN
   async function handleAddPhoto() {
     if (photos.length >= MAX_PHOTOS || !localDpId) return;
 
-    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (status !== 'granted') {
-      Alert.alert('Permission needed', 'Please allow access to your photo library in Settings.');
-      return;
-    }
-
-    const result = await ImagePicker.launchImageLibraryAsync({ mediaTypes: 'images', quality: 1 });
-    if (result.canceled || !result.assets?.[0]) return;
+    const uri = await pickAndResizePhoto();
+    if (!uri) return;
 
     setUploading(true);
     try {
-      const asset = result.assets[0];
-      const ctx = ImageManipulator.manipulate(asset.uri);
-      ctx.resize({ width: 1200 });
-      const imageRef = await ctx.renderAsync();
-      const saved = await imageRef.saveAsync({ compress: 0.8, format: SaveFormat.JPEG });
-
-      const { path, error: uploadError } = await uploadPhoto(
-        userId,
-        saved.uri,
-        `${Date.now()}.jpg`
-      );
+      const { path, error: uploadError } = await uploadPhoto(userId, uri, `${Date.now()}.jpg`);
       if (uploadError) throw uploadError;
 
       const { error: insertError } = await insertPhoto(localDpId, path, photos.length, null);

--- a/components/profile/PromptsTab.tsx
+++ b/components/profile/PromptsTab.tsx
@@ -124,7 +124,11 @@ export function PromptsTab({ form, data, onRefresh }: Props) {
                 className="flex-row gap-2.5 mt-[14px] pt-3"
                 style={{ borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.divider }}
               >
-                <FaceAvatar initials={getInitials((r as any).author?.chosen_name)} size={28} />
+                <FaceAvatar
+                  initials={getInitials((r as any).author?.chosen_name)}
+                  size={28}
+                  photoUri={(r as any).author?.avatar_url ?? null}
+                />
                 <View className="flex-1">
                   <Text className="text-xs font-semibold text-fg-muted mb-[3px]">
                     {(r as any).author?.chosen_name ?? 'Wingperson'}
@@ -160,6 +164,7 @@ export function PromptsTab({ form, data, onRefresh }: Props) {
                       <FaceAvatar
                         initials={getInitials((r as any).author?.chosen_name)}
                         size={28}
+                        photoUri={(r as any).author?.avatar_url ?? null}
                       />
                       <View className="flex-1">
                         <Text className="text-sm text-fg leading-5">{r.message}</Text>

--- a/components/ui/FaceAvatar.tsx
+++ b/components/ui/FaceAvatar.tsx
@@ -1,3 +1,4 @@
+import { Image } from 'expo-image';
 import { View, Text } from '@/lib/tw';
 import { colors } from '@/constants/theme';
 
@@ -5,9 +6,19 @@ type Props = {
   initials: string;
   bg?: string;
   size?: number;
+  photoUri?: string | null;
 };
 
-export function FaceAvatar({ initials, bg = colors.purpleSoft, size = 40 }: Props) {
+export function FaceAvatar({ initials, bg = colors.purpleSoft, size = 40, photoUri }: Props) {
+  if (photoUri) {
+    return (
+      <Image
+        source={{ uri: photoUri }}
+        style={{ width: size, height: size, borderRadius: size / 2 }}
+        contentFit="cover"
+      />
+    );
+  }
   return (
     <View
       className="items-center justify-center"

--- a/components/ui/WingStack.tsx
+++ b/components/ui/WingStack.tsx
@@ -5,18 +5,28 @@ import { FaceAvatar } from './FaceAvatar';
 const BG_COLORS = ['#D9D4FF', '#C7F2E0', '#FEF3C7', '#FCE7F3', '#DBEAFE'];
 const OVERLAP = 10;
 
+export type WingStackItem = {
+  initials: string;
+  photoUri?: string | null;
+};
+
 type Props = {
-  initials: string[];
+  items: WingStackItem[];
   size?: number;
 };
 
-export function WingStack({ initials, size = 36 }: Props) {
-  if (initials.length === 0) return null;
+export function WingStack({ items, size = 36 }: Props) {
+  if (items.length === 0) return null;
   return (
     <View className="flex-row">
-      {initials.map((init, i) => (
+      {items.map((item, i) => (
         <View key={i} style={{ marginLeft: i === 0 ? 0 : -OVERLAP, zIndex: i }}>
-          <FaceAvatar initials={init} size={size} bg={BG_COLORS[i % BG_COLORS.length]} />
+          <FaceAvatar
+            initials={item.initials}
+            size={size}
+            bg={BG_COLORS[i % BG_COLORS.length]}
+            photoUri={item.photoUri}
+          />
         </View>
       ))}
     </View>

--- a/queries/contacts.ts
+++ b/queries/contacts.ts
@@ -13,7 +13,7 @@ export function getMyWingpeople(daterId: string) {
     .select(
       `
       id, created_at,
-      winger:profiles!contacts_winger_id_fkey (id, chosen_name, gender)
+      winger:profiles!contacts_winger_id_fkey (id, chosen_name, gender, avatar_url)
     `
     )
     .eq('user_id', daterId)
@@ -79,7 +79,7 @@ export function getWingingFor(wingerId: string) {
       `
       id, created_at,
       dater:profiles!contacts_user_id_fkey (
-        id, chosen_name,
+        id, chosen_name, avatar_url,
         dating_profiles (interests, bio)
       )
     `

--- a/queries/photos.ts
+++ b/queries/photos.ts
@@ -11,7 +11,12 @@ import { supabase } from '@/lib/supabase';
  * the selected image to a max width of 1200px at 0.8 JPEG quality.
  * Returns the local URI of the processed image, or null if cancelled/denied.
  */
-export async function pickAndResizePhoto(): Promise<string | null> {
+export async function pickAndResizePhoto(opts?: {
+  width?: number;
+  aspect?: [number, number];
+}): Promise<string | null> {
+  const { width = 1200, aspect } = opts ?? {};
+
   const { granted } = await ImagePicker.requestMediaLibraryPermissionsAsync();
   if (!granted) {
     toast.error('Allow photo access in Settings.');
@@ -20,12 +25,13 @@ export async function pickAndResizePhoto(): Promise<string | null> {
   const result = await ImagePicker.launchImageLibraryAsync({
     mediaTypes: ['images'],
     allowsEditing: true,
+    aspect,
     quality: 1,
   });
   if (result.canceled || !result.assets[0]) return null;
 
   const ctx = ImageManipulator.manipulate(result.assets[0].uri);
-  ctx.resize({ width: 1200 });
+  ctx.resize({ width });
   const imageRef = await ctx.renderAsync();
   const saved = await imageRef.saveAsync({ compress: 0.8, format: SaveFormat.JPEG });
   return saved.uri;

--- a/queries/photos.ts
+++ b/queries/photos.ts
@@ -31,6 +31,36 @@ export async function pickAndResizePhoto(): Promise<string | null> {
   return saved.uri;
 }
 
+// ── Avatar ────────────────────────────────────────────────────────────────────
+
+/**
+ * Upload a JPEG to the avatars bucket as <userId>.jpg (upsert), then persist
+ * the resulting public URL to profiles.avatar_url.
+ */
+export async function uploadAvatar(
+  userId: string,
+  uri: string
+): Promise<{ url: string | null; error: Error | null }> {
+  const path = `${userId}.jpg`;
+  const arrayBuffer = await fetch(uri).then((res) => res.arrayBuffer());
+
+  const { error: uploadError } = await supabase.storage
+    .from('avatars')
+    .upload(path, arrayBuffer, { contentType: 'image/jpeg', upsert: true });
+
+  if (uploadError) return { url: null, error: uploadError };
+
+  const { data } = supabase.storage.from('avatars').getPublicUrl(path);
+  const url = data.publicUrl;
+
+  const { error: profileError } = await supabase
+    .from('profiles')
+    .update({ avatar_url: url })
+    .eq('id', userId);
+
+  return { url, error: profileError ?? null };
+}
+
 // ── Upload ────────────────────────────────────────────────────────────────────
 
 /**

--- a/queries/profiles.ts
+++ b/queries/profiles.ts
@@ -27,7 +27,7 @@ export function getOwnDatingProfile(userId: string) {
         template:prompt_templates (id, question),
         responses:prompt_responses (
           id, message, is_approved, user_id, created_at,
-          author:profiles!prompt_responses_user_id_fkey (id, chosen_name)
+          author:profiles!prompt_responses_user_id_fkey (id, chosen_name, avatar_url)
         )
       )
     `

--- a/supabase/migrations/20260402000000_avatar_storage.sql
+++ b/supabase/migrations/20260402000000_avatar_storage.sql
@@ -1,0 +1,24 @@
+-- Create avatars bucket for user profile pictures.
+-- Visibility is enforced at the application layer: only active wingers
+-- receive the avatar URL in their queries.
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+-- Users can upload/replace their own avatar (one file per user: <uid>.jpg)
+create policy "avatar_owner_insert"
+  on storage.objects for insert to authenticated
+  with check (bucket_id = 'avatars' and name = (auth.uid()::text || '.jpg'));
+
+create policy "avatar_owner_update"
+  on storage.objects for update to authenticated
+  using (bucket_id = 'avatars' and name = (auth.uid()::text || '.jpg'));
+
+create policy "avatar_owner_delete"
+  on storage.objects for delete to authenticated
+  using (bucket_id = 'avatars' and name = (auth.uid()::text || '.jpg'));
+
+-- Public read: anyone with the URL can load the image (URL only surfaced to wingers in-app)
+create policy "avatar_public_read"
+  on storage.objects for select to public
+  using (bucket_id = 'avatars');


### PR DESCRIPTION
## Summary
- Add `avatars` Supabase storage bucket (owner-write, public-read) and `uploadAvatar()` function that upserts to `avatars/<uid>.jpg` and writes the URL to `profiles.avatar_url`
- `FaceAvatar`: new `photoUri` prop renders a circular `expo-image`; falls back to initials when unset
- `WingStack`: prop updated from `initials: string[]` to `items: WingStackItem[]` to carry optional photo URIs alongside initials
- Contact queries (`getMyWingpeople`, `getWingingFor`) and prompt author select now include `avatar_url` — only surfaced for active winger relationships, never for matches or strangers
- Profile screen: tappable `AvatarPicker` component (camera badge overlay) for both daters and wingers to set/replace their picture

## Test plan
- [ ] Winger: tap avatar on profile screen → picks photo → circle updates to photo
- [ ] Dater: tap avatar on profile screen → picks photo → circle updates to photo
- [ ] Winger opens Wingpeople screen → "You're Winging For" row shows dater's photo
- [ ] Dater opens Wingpeople screen → "Your Wingpeople" row shows winger's photo
- [ ] Dater's PromptsTab → winger comment avatars show photos
- [ ] WingStack on dater profile header shows winger photos
- [ ] Messages list still shows initials (no winger relationship = no photo)
- [ ] Users without a photo set still see the initials circle fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)