### PR TITLE
feat: winger can suggest photos and comment on prompts for daters

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -45,10 +45,21 @@ function DiscoverPausedScreen({
     formState: { isSubmitting },
   } = useForm();
 
-  const copy =
-    status === 'break'
-      ? "You've paused Discover. Take all the time you need — your profile is hidden while you're on a break."
-      : "You're in winging mode. You can't browse Discover while winging for someone else.";
+  if (status === 'winging') {
+    return (
+      <SafeAreaView className="flex-1 bg-page">
+        <LargeHeader title="Discover" />
+        <View className="flex-1 justify-center items-center p-6">
+          <Text className="text-2xl font-bold font-serif text-fg text-center">
+            Nothing to see here...
+          </Text>
+          <Text className="text-sm text-fg-muted text-center mt-2" style={{ lineHeight: 22 }}>
+            you{"'"}re just winging!
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   async function resume() {
     const { error: err } = await updateDatingProfile(userId, { dating_status: 'open' });
@@ -64,10 +75,10 @@ function DiscoverPausedScreen({
       <LargeHeader title="Discover" />
       <View className="flex-1 justify-center items-center p-6 gap-4">
         <Text className="text-2xl font-bold font-serif text-fg text-center">
-          {status === 'break' ? "You're on a break" : "You're winging"}
+          You{"'"}re on a break
         </Text>
         <Text className="text-sm text-fg-muted text-center" style={{ lineHeight: 22 }}>
-          {copy}
+          Your profile is hidden while you{"'"}re on a break. Take all the time you need.
         </Text>
         <PurpleButton
           label="Resume Discover"

--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -157,7 +157,7 @@ function ProfileScreenInner() {
         <LargeHeader title="My Profile" right={<LogOutButton />} />
         <ProfileBanner
           title="You're in winging mode"
-          sub="Your dating profile is hidden. Tap to resume dating."
+          sub="Tap here to create a dating profile."
           onPress={handleResumeDating}
         />
         <WingerView name={profile?.chosen_name ?? null} />

--- a/app/(tabs)/profile/wingpeople/dater-profile.tsx
+++ b/app/(tabs)/profile/wingpeople/dater-profile.tsx
@@ -8,8 +8,6 @@ import {
   StyleSheet,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import * as ImagePicker from 'expo-image-picker';
-import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import { toast } from 'sonner-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -17,7 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { colors } from '@/constants/theme';
 import { useAuth } from '@/context/auth';
 import { useDaterProfile, getDaterProfile } from '@/queries/profiles';
-import { uploadPhoto, insertPhoto, getPhotoUrl } from '@/queries/photos';
+import { uploadPhoto, insertPhoto, getPhotoUrl, pickAndResizePhoto } from '@/queries/photos';
 import { addPromptResponse } from '@/queries/prompts';
 
 import { View, Text, Pressable, ScrollView, SafeAreaView, TextInput } from '@/lib/tw';
@@ -119,27 +117,13 @@ function DaterProfileContent() {
   );
 
   const handleSuggestPhoto = async () => {
-    const { granted } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (!granted) {
-      toast.error('Allow photo access in Settings to suggest photos.');
-      return;
-    }
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ['images'],
-      allowsEditing: true,
-      quality: 1,
-    });
-    if (result.canceled || !result.assets[0]) return;
+    const uri = await pickAndResizePhoto();
+    if (!uri) return;
 
     setUploading(true);
     try {
-      const asset = result.assets[0];
-      const ctx = ImageManipulator.manipulate(asset.uri);
-      ctx.resize({ width: 1200 });
-      const imageRef = await ctx.renderAsync();
-      const saved = await imageRef.saveAsync({ compress: 0.8, format: SaveFormat.JPEG });
       const filename = `${Date.now()}.jpg`;
-      const { path, error: upErr } = await uploadPhoto(wingerId, saved.uri, filename);
+      const { path, error: upErr } = await uploadPhoto(wingerId, uri, filename);
       if (upErr) throw upErr;
       const nextOrder = approvedPhotos.length + myPendingPhotos.length;
       const { error: insErr } = await insertPhoto(daterProfile!.id, path, nextOrder, wingerId);

--- a/app/(tabs)/profile/wingpeople/dater-profile.tsx
+++ b/app/(tabs)/profile/wingpeople/dater-profile.tsx
@@ -1,0 +1,274 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Dimensions,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+import { toast } from 'sonner-native';
+import { useQueryClient } from '@tanstack/react-query';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { colors } from '@/constants/theme';
+import { useAuth } from '@/context/auth';
+import { useDaterProfile, getDaterProfile } from '@/queries/profiles';
+import { uploadPhoto, insertPhoto, getPhotoUrl } from '@/queries/photos';
+import { addPromptResponse } from '@/queries/prompts';
+
+import { View, Text, Pressable, ScrollView, SafeAreaView, TextInput } from '@/lib/tw';
+import { NavHeader } from '@/components/ui/NavHeader';
+import { PhotoRect } from '@/components/ui/PhotoRect';
+import { PurpleButton } from '@/components/ui/PurpleButton';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import ScreenSuspense from '@/components/ui/ScreenSuspense';
+
+const PHOTO_COL = (Dimensions.get('window').width - 20 * 2 - 8) / 2;
+
+// ── ResponseModal ─────────────────────────────────────────────────────────────
+
+function ResponseModal({
+  visible,
+  promptQuestion,
+  onSubmit,
+  onDismiss,
+}: {
+  visible: boolean;
+  promptQuestion: string;
+  onSubmit: (message: string) => void;
+  onDismiss: () => void;
+}) {
+  const insets = useSafeAreaInsets();
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = () => {
+    if (!message.trim()) return;
+    onSubmit(message.trim());
+    setMessage('');
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onDismiss}>
+      <View className="flex-1 bg-black/45">
+        <Pressable className="flex-1" onPress={onDismiss} />
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}
+        >
+          <View
+            className="bg-white rounded-t-[20px] px-6 pt-3"
+            style={{ paddingBottom: insets.bottom + 20 }}
+          >
+            <View className="self-center w-9 h-1 rounded-full bg-fg-ghost mb-5" />
+            <Text className="text-xs font-semibold text-fg-muted uppercase tracking-[0.6px] mb-1">
+              Prompt
+            </Text>
+            <Text className="text-sm font-semibold text-fg mb-4" numberOfLines={2}>
+              {promptQuestion}
+            </Text>
+            <TextInput
+              className="border-[1.5px] border-separator rounded-xl px-4 py-[14px] text-sm text-fg bg-white min-h-[100px]"
+              placeholder="Write a comment on this prompt..."
+              placeholderTextColor={colors.inkGhost}
+              multiline
+              numberOfLines={4}
+              value={message}
+              onChangeText={setMessage}
+              textAlignVertical="top"
+              autoFocus
+            />
+            <View className="mt-4">
+              <PurpleButton
+                label="Send Comment"
+                onPress={handleSubmit}
+                disabled={!message.trim()}
+              />
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </View>
+    </Modal>
+  );
+}
+
+// ── DaterProfileContent ───────────────────────────────────────────────────────
+
+function DaterProfileContent() {
+  const router = useRouter();
+  const { userId: wingerId } = useAuth();
+  const { daterId } = useLocalSearchParams<{ daterId: string }>();
+  const queryClient = useQueryClient();
+
+  const { data: daterProfile } = useDaterProfile(daterId);
+  const [uploading, setUploading] = useState(false);
+  const [respondingToPrompt, setRespondingToPrompt] = useState<{
+    id: string;
+    question: string;
+  } | null>(null);
+
+  const daterName = (daterProfile?.user as any)?.chosen_name ?? 'them';
+  const firstName = daterName.split(' ')[0] || daterName;
+
+  const approvedPhotos = (daterProfile?.photos ?? []).filter((p) => p.approved_at !== null);
+  const myPendingPhotos = (daterProfile?.photos ?? []).filter(
+    (p) => p.approved_at === null && p.suggester_id === wingerId
+  );
+
+  const handleSuggestPhoto = async () => {
+    const { granted } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!granted) {
+      toast.error('Allow photo access in Settings to suggest photos.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      quality: 1,
+    });
+    if (result.canceled || !result.assets[0]) return;
+
+    setUploading(true);
+    try {
+      const asset = result.assets[0];
+      const ctx = ImageManipulator.manipulate(asset.uri);
+      ctx.resize({ width: 1200 });
+      const imageRef = await ctx.renderAsync();
+      const saved = await imageRef.saveAsync({ compress: 0.8, format: SaveFormat.JPEG });
+      const filename = `${Date.now()}.jpg`;
+      const { path, error: upErr } = await uploadPhoto(wingerId, saved.uri, filename);
+      if (upErr) throw upErr;
+      const nextOrder = approvedPhotos.length + myPendingPhotos.length;
+      const { error: insErr } = await insertPhoto(daterProfile!.id, path, nextOrder, wingerId);
+      if (insErr) throw insErr;
+      queryClient.invalidateQueries({ queryKey: [getDaterProfile, daterId] });
+      toast.success(`Photo suggested — ${firstName} will review it.`);
+    } catch {
+      toast.error('Failed to suggest photo. Please try again.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleSubmitResponse = async (message: string) => {
+    if (!respondingToPrompt) return;
+    const { error } = await addPromptResponse(wingerId, respondingToPrompt.id, message);
+    setRespondingToPrompt(null);
+    if (error) {
+      toast.error("Couldn't send comment. Try again.");
+      return;
+    }
+    toast.success(`Comment sent — ${firstName} will review it.`);
+  };
+
+  return (
+    <>
+      <NavHeader back title={`${firstName}'s Profile`} onBack={() => router.back()} />
+
+      <ScrollView showsVerticalScrollIndicator={false} contentContainerClassName="pb-12">
+        {/* ── Photos ──────────────────────────────────────────────────────── */}
+        <Text className="text-xs font-bold text-fg-subtle uppercase tracking-[0.6px] px-5 pt-6 pb-[10px]">
+          Photos
+        </Text>
+
+        {approvedPhotos.length === 0 && myPendingPhotos.length === 0 ? (
+          <Text className="text-sm text-fg-muted px-5 mb-4">No photos yet.</Text>
+        ) : (
+          <View className="flex-row flex-wrap gap-2 px-5 mb-4">
+            {approvedPhotos.map((photo) => (
+              <View key={photo.id} style={{ width: PHOTO_COL }}>
+                <PhotoRect uri={getPhotoUrl(photo.storage_url)} ratio={4 / 5} />
+              </View>
+            ))}
+            {myPendingPhotos.map((photo) => (
+              <View key={photo.id} style={{ width: PHOTO_COL, position: 'relative' }}>
+                <PhotoRect uri={getPhotoUrl(photo.storage_url)} ratio={4 / 5} blur />
+                <View className="absolute bottom-2 left-0 right-0 items-center">
+                  <View
+                    className="rounded-full px-3 py-1"
+                    style={{ backgroundColor: 'rgba(0,0,0,0.55)' }}
+                  >
+                    <Text className="text-white text-xs font-semibold">Pending approval</Text>
+                  </View>
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+
+        <Pressable
+          className="flex-row items-center justify-center gap-2 mx-5 border-[1.5px] border-accent border-dashed rounded-xl py-[14px] min-h-[52px]"
+          onPress={handleSuggestPhoto}
+          disabled={uploading}
+        >
+          {uploading ? (
+            <ActivityIndicator color={colors.purple} size="small" />
+          ) : (
+            <>
+              <IconSymbol name="plus" size={18} color={colors.purple} />
+              <Text className="text-sm font-semibold text-accent">Suggest a Photo</Text>
+            </>
+          )}
+        </Pressable>
+
+        {/* ── Prompts ─────────────────────────────────────────────────────── */}
+        <Text className="text-xs font-bold text-fg-subtle uppercase tracking-[0.6px] px-5 pt-6 pb-[10px]">
+          Prompts
+        </Text>
+
+        {(daterProfile?.prompts ?? []).length === 0 ? (
+          <Text className="text-sm text-fg-muted px-5">
+            {firstName} hasn{"'"}t added any prompts yet.
+          </Text>
+        ) : (
+          <View className="px-5 gap-3">
+            {(daterProfile?.prompts ?? []).map((prompt) => {
+              const question = (prompt.template as any)?.question ?? '';
+              return (
+                <View key={prompt.id} className="bg-white rounded-xl p-4">
+                  <Text className="text-sm font-semibold text-accent mb-1.5">{question}</Text>
+                  <Text className="text-base text-fg leading-[22px] font-serif">
+                    {prompt.answer}
+                  </Text>
+                  <Pressable
+                    className="mt-3 pt-3 flex-row items-center gap-1.5"
+                    style={{
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: colors.divider,
+                    }}
+                    onPress={() => setRespondingToPrompt({ id: prompt.id, question })}
+                  >
+                    <IconSymbol name="bubble.left" size={14} color={colors.purple} />
+                    <Text className="text-sm font-semibold text-accent">Add Comment</Text>
+                  </Pressable>
+                </View>
+              );
+            })}
+          </View>
+        )}
+      </ScrollView>
+
+      <ResponseModal
+        visible={respondingToPrompt !== null}
+        promptQuestion={respondingToPrompt?.question ?? ''}
+        onSubmit={handleSubmitResponse}
+        onDismiss={() => setRespondingToPrompt(null)}
+      />
+    </>
+  );
+}
+
+// ── Screen ────────────────────────────────────────────────────────────────────
+
+export default function DaterProfileScreen() {
+  return (
+    <SafeAreaView className="flex-1 bg-page" edges={['top']}>
+      <ScreenSuspense>
+        <DaterProfileContent />
+      </ScreenSuspense>
+    </SafeAreaView>
+  );
+}

--- a/app/(tabs)/profile/wingpeople/index.tsx
+++ b/app/(tabs)/profile/wingpeople/index.tsx
@@ -265,6 +265,16 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
               <Pressable
                 className="px-[14px] py-2 rounded-full bg-accent-muted"
                 onPress={() =>
+                  router.push(
+                    `/(tabs)/profile/wingpeople/dater-profile?daterId=${dater?.id}` as any
+                  )
+                }
+              >
+                <Text className="text-sm font-semibold text-accent">Add to profile</Text>
+              </Pressable>
+              <Pressable
+                className="px-[14px] py-2 rounded-full bg-accent-muted"
+                onPress={() =>
                   router.push(`/(tabs)/profile/wingpeople/wingswipe?daterId=${dater?.id}` as any)
                 }
               >

--- a/components/profile/PhotosTab.tsx
+++ b/components/profile/PhotosTab.tsx
@@ -1,6 +1,4 @@
 import { Alert, ActivityIndicator, Dimensions } from 'react-native';
-import * as ImagePicker from 'expo-image-picker';
-import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import { useState } from 'react';
 import { toast } from 'sonner-native';
 import type { UseFormReturn } from 'react-hook-form';
@@ -15,6 +13,7 @@ import {
   getPhotoUrl,
   reorderPhotos,
   deleteOwnPhoto,
+  pickAndResizePhoto,
 } from '@/queries/photos';
 
 import { ScrollView, Text, Pressable, View } from '@/lib/tw';
@@ -109,27 +108,13 @@ export function PhotosTab({ form, data, userId, onRefresh }: Props) {
   };
 
   const handleAddPhoto = async () => {
-    const { granted } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (!granted) {
-      toast.error('Allow photo access in Settings to add photos.');
-      return;
-    }
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ['images'],
-      allowsEditing: true,
-      quality: 1,
-    });
-    if (result.canceled || !result.assets[0]) return;
+    const uri = await pickAndResizePhoto();
+    if (!uri) return;
 
     setUploading(true);
     try {
-      const asset = result.assets[0];
-      const ctx = ImageManipulator.manipulate(asset.uri);
-      ctx.resize({ width: 1200 });
-      const imageRef = await ctx.renderAsync();
-      const saved = await imageRef.saveAsync({ compress: 0.8, format: SaveFormat.JPEG });
       const filename = `${Date.now()}.jpg`;
-      const { path, error: upErr } = await uploadPhoto(userId, saved.uri, filename);
+      const { path, error: upErr } = await uploadPhoto(userId, uri, filename);
       if (upErr) throw upErr;
       const { error: insErr } = await insertPhoto(data.id, path, selfPhotos.length, null);
       if (insErr) throw insErr;

--- a/queries/photos.ts
+++ b/queries/photos.ts
@@ -1,4 +1,35 @@
+import * as ImagePicker from 'expo-image-picker';
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+import { toast } from 'sonner-native';
+
 import { supabase } from '@/lib/supabase';
+
+// ── Photo picker ──────────────────────────────────────────────────────────────
+
+/**
+ * Prompts for media library permission, opens the image picker, and resizes
+ * the selected image to a max width of 1200px at 0.8 JPEG quality.
+ * Returns the local URI of the processed image, or null if cancelled/denied.
+ */
+export async function pickAndResizePhoto(): Promise<string | null> {
+  const { granted } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!granted) {
+    toast.error('Allow photo access in Settings.');
+    return null;
+  }
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    allowsEditing: true,
+    quality: 1,
+  });
+  if (result.canceled || !result.assets[0]) return null;
+
+  const ctx = ImageManipulator.manipulate(result.assets[0].uri);
+  ctx.resize({ width: 1200 });
+  const imageRef = await ctx.renderAsync();
+  const saved = await imageRef.saveAsync({ compress: 0.8, format: SaveFormat.JPEG });
+  return saved.uri;
+}
 
 // ── Upload ────────────────────────────────────────────────────────────────────
 

--- a/queries/profiles.ts
+++ b/queries/profiles.ts
@@ -77,6 +77,49 @@ export function useProfileData(userId: string) {
   });
 }
 
+// ── Winger: read a dater's profile ───────────────────────────────────────────
+
+/**
+ * Fetch a dater's dating profile as seen by their winger.
+ * Includes approved photos, winger-suggested photos, and profile prompts.
+ * Does NOT include prompt responses (those are private to the dater).
+ */
+export function getDaterProfile(daterId: string) {
+  return supabase
+    .from('dating_profiles')
+    .select(
+      `
+      id,
+      user:profiles!dating_profiles_user_id_fkey (id, chosen_name),
+      photos:profile_photos (
+        id, storage_url, display_order, approved_at, suggester_id
+      ),
+      prompts:profile_prompts (
+        id, answer, created_at,
+        template:prompt_templates (id, question)
+      )
+    `
+    )
+    .eq('user_id', daterId)
+    .order('display_order', { referencedTable: 'profile_photos', ascending: true })
+    .order('created_at', { referencedTable: 'profile_prompts', ascending: true })
+    .maybeSingle();
+}
+
+export type DaterProfile = NonNullable<Awaited<ReturnType<typeof getDaterProfile>>['data']>;
+
+export function useDaterProfile(daterId: string) {
+  return useSuspenseQuery({
+    queryKey: [getDaterProfile, daterId],
+    queryFn: async () => {
+      const { data, error } = await getDaterProfile(daterId);
+      if (error) throw error;
+      return data;
+    },
+    staleTime: 2 * 60_000,
+  });
+}
+
 // ── Onboarding writes ─────────────────────────────────────────────────────────
 
 /** Step 1: write name, DOB, phone, gender, role collected during onboarding. */


### PR DESCRIPTION
## Summary
- Adds a new **dater profile screen** (`wingpeople/dater-profile.tsx`) accessible to wingers from the "You're Winging For" list via a new **"Add to profile"** button (alongside the existing "Swipe for" button)
- **Photos section**: read-only grid of the dater's approved photos; winger's own pending suggestions shown blurred with a "Pending approval" badge; "Suggest a Photo" button picks from camera roll, resizes to 1200px JPEG, uploads to storage, and inserts a `profile_photos` row with `suggester_id` set and `approved_at = null`
- **Prompts section**: each of the dater's prompt cards with "Add Comment" button; opens a bottom sheet modal with a text field; submits via `addPromptResponse` with `is_approved = false`
- Dater approves/rejects suggested photos in their Photos tab and prompt comments in their Prompts tab (approval UI already existed)
- New `getDaterProfile` / `useDaterProfile` query in `queries/profiles.ts` fetches a dater's dating profile (photos + prompts, no responses) for the winger view

## Test plan
- [ ] "You're Winging For" rows show both "Add to profile" and "Swipe for [name]" buttons
- [ ] Tap "Add to profile" → navigates to dater profile screen
- [ ] Suggest a photo → appears blurred with "Pending approval" badge; dater sees it in their Photos tab under "Suggested by Wingpeople"
- [ ] Dater approves → photo moves to their main grid
- [ ] Tap "Add Comment" on a prompt → bottom sheet opens with the prompt question shown
- [ ] Submit comment → toast confirms; dater sees it in Prompts tab under "N wingperson comments waiting"
- [ ] Dater approves comment → appears under the prompt answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)