### PR TITLE
feat: swipeable card carousel for approved winger prompt comments

### DIFF
--- a/components/profile/PromptsTab.tsx
+++ b/components/profile/PromptsTab.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
-import { Alert, StyleSheet } from 'react-native';
+import {
+  Alert,
+  Dimensions,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  StyleSheet,
+} from 'react-native';
 import { toast } from 'sonner-native';
 import type { UseFormReturn } from 'react-hook-form';
 
@@ -16,6 +22,79 @@ import { IconSymbol } from '@/components/ui/icon-symbol';
 import { ScrollView, Text, View, Pressable } from '@/lib/tw';
 import { AddPromptModal } from './AddPromptModal';
 import { getInitials } from './profile-helpers';
+
+// ── Approved responses carousel ───────────────────────────────────────────────
+
+// screen width minus the two levels of padding: px-5 (20px) on the tab + p-4 (16px) on the card
+const SLIDE_WIDTH = Dimensions.get('window').width - 20 * 2 - 16 * 2;
+const PEEK = 20; // px of next card visible to hint at swiping
+const SNAP_INTERVAL = SLIDE_WIDTH - PEEK + 8; // slide width minus peek + gap between slides
+
+type ApprovedResponse = OwnDatingProfile['prompts'][number]['responses'][number];
+
+function ApprovedResponsesCarousel({ responses }: { responses: ApprovedResponse[] }) {
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  const handleScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    setActiveIdx(Math.round(e.nativeEvent.contentOffset.x / SNAP_INTERVAL));
+  };
+
+  return (
+    <View
+      className="mt-[14px] pt-3"
+      style={{ borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.divider }}
+    >
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        decelerationRate="fast"
+        snapToInterval={SNAP_INTERVAL}
+        onMomentumScrollEnd={handleScroll}
+        contentContainerStyle={{ paddingRight: PEEK }}
+      >
+        {responses.map((r, i) => (
+          <View
+            key={r.id}
+            className="bg-page rounded-xl p-3"
+            style={{
+              width: SLIDE_WIDTH - PEEK,
+              marginRight: i < responses.length - 1 ? 8 : 0,
+            }}
+          >
+            <View className="flex-row gap-2.5">
+              <FaceAvatar
+                initials={getInitials((r as any).author?.chosen_name)}
+                size={28}
+                photoUri={(r as any).author?.avatar_url ?? null}
+              />
+              <View className="flex-1">
+                <Text className="text-xs font-semibold text-fg-muted mb-[3px]">
+                  {(r as any).author?.chosen_name ?? 'Wingperson'}
+                </Text>
+                <Text className="text-sm text-fg leading-5">{r.message}</Text>
+              </View>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+      {responses.length > 1 && (
+        <View className="flex-row justify-center gap-1.5 mt-3">
+          {responses.map((_, i) => (
+            <View
+              key={i}
+              style={{
+                width: i === activeIdx ? 14 : 6,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: i === activeIdx ? colors.purple : colors.inkGhost,
+              }}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
 
 interface Props {
   form: UseFormReturn<OwnDatingProfile>;
@@ -117,26 +196,8 @@ export function PromptsTab({ form, data, onRefresh }: Props) {
             </Text>
             <Text className="text-base text-fg leading-[22px] font-serif">{prompt.answer}</Text>
 
-            {/* Approved wing comments */}
-            {approvedR.map((r) => (
-              <View
-                key={r.id}
-                className="flex-row gap-2.5 mt-[14px] pt-3"
-                style={{ borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.divider }}
-              >
-                <FaceAvatar
-                  initials={getInitials((r as any).author?.chosen_name)}
-                  size={28}
-                  photoUri={(r as any).author?.avatar_url ?? null}
-                />
-                <View className="flex-1">
-                  <Text className="text-xs font-semibold text-fg-muted mb-[3px]">
-                    {(r as any).author?.chosen_name ?? 'Wingperson'}
-                  </Text>
-                  <Text className="text-sm text-fg leading-5">{r.message}</Text>
-                </View>
-              </View>
-            ))}
+            {/* Approved wing comments — swipeable card carousel */}
+            {approvedR.length > 0 && <ApprovedResponsesCarousel responses={approvedR} />}
 
             {/* Pending responses */}
             {pendingR.length > 0 && (

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "build:local": "EAS_BUILD_NO_EXPO_GO_WARNING=true eas build --platform ios --profile production --local --output builds/app.ipa",
     "build:device": "expo run:ios --device",
     "submit:local": "eas submit --platform ios --profile production --path builds/app.ipa",
+    "seed:sam": "bash scripts/seed-sam.sh",
+    "seed:winger-responses": "bash scripts/seed-winger-responses.sh",
     "seed:prod": "npx tsx --env-file .env.local scripts/seed-prod.ts",
     "prepare": "husky"
   },

--- a/scripts/seed-sam.sh
+++ b/scripts/seed-sam.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+set -e
+cd "$(dirname "$0")/.."
+
+echo "==> Loading local Supabase credentials..."
+
+JWT_KEYS=$(docker exec supabase_auth_wingmate env 2>/dev/null | grep '^GOTRUE_JWT_KEYS=' | cut -d'=' -f2-)
+JWT_SECRET=$(docker exec supabase_auth_wingmate env 2>/dev/null | grep '^GOTRUE_JWT_SECRET=' | cut -d'=' -f2-)
+
+if [ -z "$JWT_KEYS" ] && [ -z "$JWT_SECRET" ]; then
+  echo "Error: Could not read JWT config from auth container. Is Supabase running? (npm run db:up)"
+  exit 1
+fi
+
+echo "==> Seeding Sam Taylor..."
+SUPABASE_URL=http://127.0.0.1:54321 \
+GOTRUE_JWT_KEYS="$JWT_KEYS" \
+GOTRUE_JWT_SECRET="$JWT_SECRET" \
+  npx tsx scripts/seed-sam.ts
+
+echo "Sam Taylor seed complete."

--- a/scripts/seed-sam.ts
+++ b/scripts/seed-sam.ts
@@ -1,0 +1,398 @@
+#!/usr/bin/env npx tsx
+/**
+ * Seed Sam Taylor — a dater the dev user wings for.
+ *
+ * Creates:
+ *   - Sam Taylor (dater, Female, interested in Male, NYC)
+ *   - 3 prompts for Sam
+ *   - 10 male potential match profiles Sam's winger can swipe through
+ *   - Active contact linking dev@local.test as Sam's winger
+ *
+ * Usage (same env setup as db-fixtures.sh):
+ *   SUPABASE_URL=http://127.0.0.1:54321 \
+ *   GOTRUE_JWT_KEYS="..." \
+ *     npx tsx scripts/seed-sam.ts
+ *
+ * Or via npm: npm run seed:sam
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { createPrivateKey } from 'crypto';
+import jwt from 'jsonwebtoken';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321';
+const GOTRUE_JWT_KEYS = process.env.GOTRUE_JWT_KEYS;
+const GOTRUE_JWT_SECRET = process.env.GOTRUE_JWT_SECRET;
+
+function makeServiceRoleJwt(): string {
+  const claims = {
+    iss: 'supabase-demo',
+    role: 'service_role',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  };
+
+  if (GOTRUE_JWT_KEYS) {
+    const jwks: { alg: string; kid?: string; d?: string }[] = JSON.parse(GOTRUE_JWT_KEYS);
+    const jwk = jwks.find((k) => k.d);
+    if (!jwk) throw new Error('No private key found in GOTRUE_JWT_KEYS');
+    const privateKey = createPrivateKey({
+      format: 'jwk',
+      key: jwk as Parameters<typeof createPrivateKey>[0] & object,
+    });
+    return jwt.sign(claims, privateKey, { algorithm: 'ES256', keyid: jwk.kid });
+  }
+
+  if (GOTRUE_JWT_SECRET) {
+    return jwt.sign(claims, GOTRUE_JWT_SECRET, { algorithm: 'HS256' });
+  }
+
+  throw new Error('Neither GOTRUE_JWT_KEYS nor GOTRUE_JWT_SECRET is set.');
+}
+
+const serviceRoleJwt = makeServiceRoleJwt();
+const supabase = createClient(SUPABASE_URL, serviceRoleJwt, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// ── Sam's prompts ─────────────────────────────────────────────────────────────
+
+const SAM_PROMPTS: { question: string; answer: string }[] = [
+  {
+    question: 'A perfect Sunday looks like…',
+    answer:
+      'a slow morning run along the Hudson, eggs somewhere with too-good coffee, then zero plans.',
+  },
+  {
+    question: "I'm looking for someone who…",
+    answer: "is curious about the world and doesn't pretend to have it all figured out.",
+  },
+  {
+    question: 'My friends would describe me as…',
+    answer: 'the one who actually makes a reservation — and then talks everyone into a detour.',
+  },
+];
+
+// ── Potential matches (men) for Sam ──────────────────────────────────────────
+
+const SAM_MATCHES: {
+  first: string;
+  last: string;
+  bio: string;
+  interests: string[];
+  religion: string;
+  photoIndex: number;
+}[] = [
+  {
+    first: 'Marcus',
+    last: 'Webb',
+    bio: 'Architecture nerd who will stop mid-walk to stare at a building. Zero apologies.',
+    interests: ['Art', 'Travel', 'Food'],
+    religion: 'Agnostic',
+    photoIndex: 10,
+  },
+  {
+    first: 'Daniel',
+    last: 'Okafor',
+    bio: 'Jazz bars and dive bars — ideally the same bar on the same night.',
+    interests: ['Music', 'Food', 'Outdoors'],
+    religion: 'Christian',
+    photoIndex: 15,
+  },
+  {
+    first: 'Tyler',
+    last: 'Brennan',
+    bio: 'I make really good playlists. This is not a small thing.',
+    interests: ['Music', 'Movies', 'Gaming'],
+    religion: 'Atheist',
+    photoIndex: 20,
+  },
+  {
+    first: 'Raj',
+    last: 'Iyer',
+    bio: 'Home cook who takes the farmers market too seriously. Farmer-market receipts available on request.',
+    interests: ['Cooking', 'Travel', 'Books'],
+    religion: 'Hindu',
+    photoIndex: 25,
+  },
+  {
+    first: 'Cole',
+    last: 'Nakamura',
+    bio: 'Will beat you at trivia night and apologize about it the whole way home.',
+    interests: ['Books', 'Technology', 'Fitness'],
+    religion: 'Agnostic',
+    photoIndex: 30,
+  },
+  {
+    first: 'Leo',
+    last: 'Ferreira',
+    bio: 'Ran the NYC Marathon once. Now I only run for the brunch at the finish line.',
+    interests: ['Fitness', 'Food', 'Travel'],
+    religion: 'Other',
+    photoIndex: 35,
+  },
+  {
+    first: 'Finn',
+    last: "O'Sullivan",
+    bio: 'True crime podcast listener who is, paradoxically, very optimistic about people.',
+    interests: ['Books', 'Movies', 'Outdoors'],
+    religion: 'Atheist',
+    photoIndex: 40,
+  },
+  {
+    first: 'Andre',
+    last: 'Moreau',
+    bio: 'Moved here from Montreal. The bagels are different but the energy is worth it.',
+    interests: ['Food', 'Art', 'Dance'],
+    religion: 'Agnostic',
+    photoIndex: 45,
+  },
+  {
+    first: 'Kai',
+    last: 'Hoffman',
+    bio: 'My ideal Saturday: bike ride along the Hudson, good coffee, no plans after noon.',
+    interests: ['Outdoors', 'Photography', 'Fitness'],
+    religion: 'Atheist',
+    photoIndex: 50,
+  },
+  {
+    first: 'Miles',
+    last: 'Ashford',
+    bio: 'Amateur stand-up comic. My friends laugh at me, not with me — close enough.',
+    interests: ['Movies', 'Music', 'Food'],
+    religion: 'Jewish',
+    photoIndex: 55,
+  },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function randomDob(minAge: number, maxAge: number): string {
+  const now = new Date();
+  const year = now.getFullYear() - minAge - Math.floor(Math.random() * (maxAge - minAge + 1));
+  const month = String(Math.floor(Math.random() * 12) + 1).padStart(2, '0');
+  const day = String(Math.floor(Math.random() * 28) + 1).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+async function getOrCreateUser(
+  email: string,
+  label: string
+): Promise<{ id: string; existed: boolean }> {
+  const { data: listData, error } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+  if (error) throw new Error(`listUsers: ${error.message}`);
+
+  const existing = listData.users.find((u) => u.email === email);
+  if (existing) return { id: existing.id, existed: true };
+
+  const { data: authData, error: authError } = await supabase.auth.admin.createUser({
+    email,
+    password: 'Orbit123!',
+    email_confirm: true,
+  });
+  if (authError) throw new Error(`${label} auth error: ${authError.message}`);
+  return { id: authData.user.id, existed: false };
+}
+
+// ── Sam Taylor ────────────────────────────────────────────────────────────────
+
+async function ensureSamTaylor(): Promise<string> {
+  const email = 'sam.taylor@seed.orbit.test';
+  const { id: userId, existed } = await getOrCreateUser(email, 'Sam Taylor');
+
+  if (existed) {
+    console.log('  Sam Taylor already exists, skipping creation');
+    return userId;
+  }
+
+  const { error: profileError } = await supabase
+    .from('profiles')
+    .update({
+      chosen_name: 'Sam',
+      last_name: 'Taylor',
+      gender: 'Female',
+      date_of_birth: randomDob(25, 30),
+      role: 'dater',
+      phone_number: '+15550020001',
+    })
+    .eq('id', userId);
+  if (profileError) throw new Error(`Sam profile error: ${profileError.message}`);
+
+  const { data: dp, error: dpError } = await supabase
+    .from('dating_profiles')
+    .insert({
+      user_id: userId,
+      bio: 'Brooklyn native, always hunting for the best bagel in the borough. Big on live music and even bigger on people who can keep up with a 9pm whim.',
+      interested_gender: ['Male'],
+      age_from: 25,
+      age_to: 38,
+      religion: 'Agnostic',
+      interests: ['Music', 'Outdoors', 'Food', 'Travel', 'Art'],
+      city: 'New York',
+      is_active: true,
+      dating_status: 'winging',
+    })
+    .select('id')
+    .single();
+  if (dpError) throw new Error(`Sam dating_profile error: ${dpError.message}`);
+
+  // Add prompts
+  const { data: templates } = await supabase.from('prompt_templates').select('id, question');
+
+  if (templates) {
+    const rows = SAM_PROMPTS.flatMap(({ question, answer }) => {
+      const template = templates.find((t) => t.question === question);
+      if (!template) {
+        console.warn(`  prompt template not found: "${question}" — skipping`);
+        return [];
+      }
+      return [{ dating_profile_id: dp.id, prompt_template_id: template.id, answer }];
+    });
+
+    if (rows.length > 0) {
+      const { error: promptError } = await supabase.from('profile_prompts').insert(rows);
+      if (promptError) throw new Error(`Sam prompts error: ${promptError.message}`);
+      console.log(`  inserted ${rows.length} prompts for Sam`);
+    }
+  }
+
+  // Add a photo
+  const { error: photoError } = await supabase.from('profile_photos').insert({
+    dating_profile_id: dp.id,
+    storage_url: `https://randomuser.me/api/portraits/women/5.jpg`,
+    display_order: 0,
+    approved_at: new Date().toISOString(),
+  });
+  if (photoError) throw new Error(`Sam photo error: ${photoError.message}`);
+
+  console.log(`  Sam Taylor created (${userId})`);
+  return userId;
+}
+
+// ── Potential match profiles ──────────────────────────────────────────────────
+
+async function ensureMatchProfile(
+  index: number,
+  first: string,
+  last: string,
+  bio: string,
+  interests: string[],
+  religion: string,
+  photoIndex: number
+): Promise<void> {
+  const email = `sam.match.${first.toLowerCase()}.${last.toLowerCase()}@seed.orbit.test`;
+  const label = `${first} ${last}`;
+  const { id: userId, existed } = await getOrCreateUser(email, label);
+
+  if (existed) {
+    console.log(`  ${label} already exists, skipping`);
+    return;
+  }
+
+  const { error: profileError } = await supabase
+    .from('profiles')
+    .update({
+      chosen_name: first,
+      last_name: last,
+      date_of_birth: randomDob(25, 35),
+      gender: 'Male',
+      role: 'dater',
+      phone_number: `+1555002${String(index + 10).padStart(4, '0')}`,
+    })
+    .eq('id', userId);
+  if (profileError) throw new Error(`${label} profile error: ${profileError.message}`);
+
+  const { data: dp, error: dpError } = await supabase
+    .from('dating_profiles')
+    .insert({
+      user_id: userId,
+      bio,
+      interested_gender: ['Female'],
+      age_from: 23,
+      age_to: 38,
+      religion,
+      interests,
+      city: 'New York',
+      is_active: true,
+      dating_status: 'open',
+    })
+    .select('id')
+    .single();
+  if (dpError) throw new Error(`${label} dating_profile error: ${dpError.message}`);
+
+  await supabase.from('profile_photos').insert([
+    {
+      dating_profile_id: dp.id,
+      storage_url: `https://randomuser.me/api/portraits/men/${photoIndex % 99}.jpg`,
+      display_order: 0,
+      approved_at: new Date().toISOString(),
+    },
+    {
+      dating_profile_id: dp.id,
+      storage_url: `https://randomuser.me/api/portraits/men/${(photoIndex + 20) % 99}.jpg`,
+      display_order: 1,
+      approved_at: new Date().toISOString(),
+    },
+  ]);
+
+  console.log(`  ${label} ✓`);
+}
+
+// ── Winger contact ────────────────────────────────────────────────────────────
+
+async function linkDevUserAsWinger(samId: string): Promise<void> {
+  const { data: listData } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+  const devUser = listData?.users.find((u) => u.email === 'dev@local.test');
+  if (!devUser) {
+    console.log('  dev@local.test not found — run npm run db:fixtures first');
+    return;
+  }
+
+  const { data: existing } = await supabase
+    .from('contacts')
+    .select('id')
+    .eq('user_id', samId)
+    .eq('winger_id', devUser.id)
+    .maybeSingle();
+
+  if (existing) {
+    console.log('  winger contact already exists, skipping');
+    return;
+  }
+
+  const { error } = await supabase.from('contacts').insert({
+    user_id: samId,
+    winger_id: devUser.id,
+    phone_number: '+15550020001',
+    wingperson_status: 'active',
+  });
+  if (error) throw new Error(`contact error: ${error.message}`);
+
+  console.log(`  dev user linked as Sam's winger ✓`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('Seeding Sam Taylor…\n');
+
+  console.log('Creating Sam Taylor (dater)…');
+  const samId = await ensureSamTaylor();
+  console.log();
+
+  console.log('Creating potential match profiles for Sam…');
+  for (let i = 0; i < SAM_MATCHES.length; i++) {
+    const m = SAM_MATCHES[i];
+    await ensureMatchProfile(i, m.first, m.last, m.bio, m.interests, m.religion, m.photoIndex);
+  }
+  console.log();
+
+  console.log("Linking dev user as Sam's winger…");
+  await linkDevUserAsWinger(samId);
+
+  console.log('\nDone. Sam Taylor is seeded and ready for the winger flow.');
+}
+
+main().catch((err) => {
+  console.error('\nSeed failed:', err);
+  process.exit(1);
+});

--- a/scripts/seed-winger-responses.sh
+++ b/scripts/seed-winger-responses.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+set -e
+cd "$(dirname "$0")/.."
+
+echo "==> Loading local Supabase credentials..."
+
+JWT_KEYS=$(docker exec supabase_auth_wingmate env 2>/dev/null | grep '^GOTRUE_JWT_KEYS=' | cut -d'=' -f2-)
+JWT_SECRET=$(docker exec supabase_auth_wingmate env 2>/dev/null | grep '^GOTRUE_JWT_SECRET=' | cut -d'=' -f2-)
+
+if [ -z "$JWT_KEYS" ] && [ -z "$JWT_SECRET" ]; then
+  echo "Error: Could not read JWT config from auth container. Is Supabase running?"
+  exit 1
+fi
+
+echo "==> Seeding winger prompt responses..."
+SUPABASE_URL=http://127.0.0.1:54321 \
+GOTRUE_JWT_KEYS="$JWT_KEYS" \
+GOTRUE_JWT_SECRET="$JWT_SECRET" \
+  npx tsx scripts/seed-winger-responses.ts
+
+echo "Done."

--- a/scripts/seed-winger-responses.ts
+++ b/scripts/seed-winger-responses.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env npx tsx
+/**
+ * Seed prompt_responses from the dev user's wingers on their profile prompts.
+ *
+ * Each winger (Alex Chen, Jordan Kim, Sam Rivera) leaves a comment on each
+ * of the dev user's prompts. Responses start unapproved so the dater sees
+ * the "N wingperson comments waiting" flow in the Prompts tab.
+ *
+ * Usage: npm run seed:winger-responses
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { createPrivateKey } from 'crypto';
+import jwt from 'jsonwebtoken';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321';
+const GOTRUE_JWT_KEYS = process.env.GOTRUE_JWT_KEYS;
+const GOTRUE_JWT_SECRET = process.env.GOTRUE_JWT_SECRET;
+
+function makeServiceRoleJwt(): string {
+  const claims = {
+    iss: 'supabase-demo',
+    role: 'service_role',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  };
+  if (GOTRUE_JWT_KEYS) {
+    const jwks: { alg: string; kid?: string; d?: string }[] = JSON.parse(GOTRUE_JWT_KEYS);
+    const jwk = jwks.find((k) => k.d);
+    if (!jwk) throw new Error('No private key found in GOTRUE_JWT_KEYS');
+    const privateKey = createPrivateKey({
+      format: 'jwk',
+      key: jwk as Parameters<typeof createPrivateKey>[0] & object,
+    });
+    return jwt.sign(claims, privateKey, { algorithm: 'ES256', keyid: jwk.kid });
+  }
+  if (GOTRUE_JWT_SECRET) {
+    return jwt.sign(claims, GOTRUE_JWT_SECRET, { algorithm: 'HS256' });
+  }
+  throw new Error('Neither GOTRUE_JWT_KEYS nor GOTRUE_JWT_SECRET is set.');
+}
+
+const supabase = createClient(SUPABASE_URL, makeServiceRoleJwt(), {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// ── Winger responses keyed by prompt question ─────────────────────────────────
+
+// Each question maps to one response per winger: [Alex, Jordan, Sam Rivera]
+const RESPONSES_BY_QUESTION: Record<string, [string, string, string]> = {
+  'The way to my heart is…': [
+    'Can confirm — bring snacks and you have their full attention.',
+    'This is 100% accurate. I have tested this theory.',
+    "Honestly though, they mean it. Don't show up empty-handed.",
+  ],
+  'A perfect Sunday looks like…': [
+    "They will genuinely not check their phone until 2pm. It's impressive.",
+    'The farmers market thing is real. They know every vendor by name.',
+    'Add "convincing everyone else to cancel their plans too" and this is perfect.',
+  ],
+  'My love language is…': [
+    "I once watched them rearrange someone else's furniture unprompted. True story.",
+    'They say quality time but they also just show up with your favorite snacks. Both.',
+    'The quiet sitting together thing sounds boring until you experience it. It is not boring.',
+  ],
+  'I get way too excited about…': [
+    'You think they are joking about this. They are not joking.',
+    'I have received approximately 14 texts about new bakery openings in the last month.',
+    'The parking spot thing — I was there. Celebration lasted longer than finding it.',
+  ],
+  "The most spontaneous thing I've done…": [
+    'I heard about this trip 36 hours before departure. Zero hesitation.',
+    'They did not pack enough socks. They do not regret a single thing.',
+    'This is the most on-brand story I have ever heard about this person.',
+  ],
+  'Two truths and a lie…': [
+    'I know which one is the lie and I am not telling you.',
+    'Asked them and they refused to confirm. Part of the charm.',
+    'I guessed wrong. Very embarrassing. Do better than me.',
+  ],
+  'My friends would describe me as…': [
+    'Can confirm. They made the reservation for my birthday before I even mentioned it.',
+    'The questions thing is real. Best conversation starter I know.',
+    'Reliably late is generous. Worth the wait is accurate.',
+  ],
+  "I'm looking for someone who…": [
+    'They will know within five minutes whether you meet this standard.',
+    'The brunch thing is non-negotiable. I have seen people fail this test.',
+    'Curious and kind. Simple bar. Somehow rare.',
+  ],
+  'Unpopular opinion I hold…': [
+    'I have seen them eat cold pizza for breakfast with zero shame. Committed.',
+    'They sent me a voice note about this at 11pm. It was persuasive.',
+    'Wrong about the 6 train, right about everything else.',
+  ],
+  'My go-to karaoke song…': [
+    'I have witnessed this. It is a full performance. Respect.',
+    'They know every word. Every. Single. Word. Do not underestimate.',
+    'Nobody in the room is ready when this song comes on.',
+  ],
+};
+
+// Fallback responses if the question isn't in our map
+const FALLBACK_RESPONSES: [string, string, string] = [
+  'I can personally vouch for this. No notes.',
+  "This is the most accurate thing they've ever written about themselves.",
+  'Knew them for years and this tracks completely.',
+];
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('Seeding winger prompt responses for dev user…\n');
+
+  // 1. Get the dev user's ID
+  const { data: listData, error: listError } = await supabase.auth.admin.listUsers({
+    perPage: 1000,
+  });
+  if (listError) throw listError;
+
+  const devUser = listData.users.find((u) => u.email === 'dev@local.test');
+  if (!devUser) throw new Error('dev@local.test not found — run npm run db:fixtures first');
+  console.log(`Dev user: ${devUser.id}`);
+
+  // 2. Get the dev user's dating profile + prompts (with template questions)
+  const { data: dp, error: dpError } = await supabase
+    .from('dating_profiles')
+    .select(`id, prompts:profile_prompts(id, template:prompt_templates(question))`)
+    .eq('user_id', devUser.id)
+    .single();
+  if (dpError) throw dpError;
+  if (!dp.prompts || dp.prompts.length === 0) {
+    console.log('Dev user has no prompts. Run npm run db:fixtures first.');
+    return;
+  }
+  console.log(`Found ${dp.prompts.length} prompts\n`);
+
+  // 3. Get the winger user IDs (Alex Chen, Jordan Kim, Sam Rivera)
+  const WINGER_EMAILS = [
+    'winger.alex.chen@seed.orbit.test',
+    'winger.jordan.kim@seed.orbit.test',
+    'winger.sam.rivera@seed.orbit.test',
+  ];
+  const wingerIds = WINGER_EMAILS.map((email) => {
+    const u = listData.users.find((u) => u.email === email);
+    if (!u) throw new Error(`Winger not found: ${email} — run npm run db:fixtures first`);
+    return u.id;
+  });
+  console.log(`Wingers: ${wingerIds.length} found`);
+
+  // 4. Insert one response per winger per prompt (skip if already exists)
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const prompt of dp.prompts) {
+    const question = (prompt.template as any)?.question ?? '';
+    const responses = RESPONSES_BY_QUESTION[question] ?? FALLBACK_RESPONSES;
+
+    console.log(`\nPrompt: "${question}"`);
+
+    for (let i = 0; i < wingerIds.length; i++) {
+      const wingerId = wingerIds[i];
+      const message = responses[i];
+
+      // Check if a response already exists from this winger on this prompt
+      const { data: existing } = await supabase
+        .from('prompt_responses')
+        .select('id')
+        .eq('user_id', wingerId)
+        .eq('profile_prompt_id', prompt.id)
+        .maybeSingle();
+
+      if (existing) {
+        console.log(`  winger ${i + 1} — already exists, skipping`);
+        skipped++;
+        continue;
+      }
+
+      const { error } = await supabase.from('prompt_responses').insert({
+        user_id: wingerId,
+        profile_prompt_id: prompt.id,
+        message,
+        is_approved: false,
+      });
+      if (error) throw new Error(`Response insert error: ${error.message}`);
+      console.log(`  winger ${i + 1} — "${message.slice(0, 60)}…"`);
+      inserted++;
+    }
+  }
+
+  console.log(`\nDone. ${inserted} responses inserted, ${skipped} skipped.`);
+  console.log('Open Profile → Prompts tab to see the pending wingperson comments.');
+}
+
+main().catch((err) => {
+  console.error('\nFailed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Approved winger prompt responses now render as horizontally swipeable cards instead of a flat list
- Each card peeks 20px to signal more content is available; pill-shaped dot indicators show position
- Pending approval flow (expand/collapse with approve/reject buttons) is unchanged
- Adds `seed:sam` and `seed:winger-responses` npm scripts + seed files for local dev testing

## Test plan
- [ ] Open Profile → Prompts tab with approved winger responses — confirm cards are swipeable
- [ ] Confirm next card peeks on the right edge
- [ ] Confirm dot indicators update as you swipe
- [ ] With only one approved response, confirm no dots appear
- [ ] Confirm pending "N wingperson comments waiting" section still works (expand, approve, reject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)