### PR TITLE
fix: winger heart tap opens note prompt; use user_id in decisions

### DIFF
--- a/app/(tabs)/profile/wingpeople/wingswipe.tsx
+++ b/app/(tabs)/profile/wingpeople/wingswipe.tsx
@@ -176,9 +176,7 @@ function WingSwipeContent() {
           <Pressable
             className="w-16 h-16 rounded-[32px] justify-center items-center bg-accent"
             style={cardButtonShadow}
-            onPress={() => suggest(null)}
-            onLongPress={() => setNoteVisible(true)}
-            delayLongPress={400}
+            onPress={() => setNoteVisible(true)}
           >
             <Text className="text-2xl text-white">♥</Text>
           </Pressable>

--- a/hooks/use-wing-swipe.ts
+++ b/hooks/use-wing-swipe.ts
@@ -31,7 +31,7 @@ export function useWingSwipe(wingerId: string, daterId: string, initialPool: Win
     setIndex(newIndex);
     if (newIndex >= pool.length - 3) loadMore();
 
-    const { error } = await wingSuggestApprove(daterId, card.profile_id, wingerId, note);
+    const { error } = await wingSuggestApprove(daterId, card.user_id, wingerId, note);
     if (error) {
       // Roll back on failure
       setIndex((prev) => prev - 1);
@@ -47,7 +47,7 @@ export function useWingSwipe(wingerId: string, daterId: string, initialPool: Win
     setIndex(newIndex);
     if (newIndex >= pool.length - 3) loadMore();
 
-    await wingSuggestDecline(daterId, card.profile_id, wingerId);
+    await wingSuggestDecline(daterId, card.user_id, wingerId);
   }
 
   return { pool, index, suggest, decline };


### PR DESCRIPTION
## Summary
- Tapping ♥ in WingSwipe now always opens the note modal — winger can add a comment or skip straight to sending
- Fixes `wingSuggestApprove` and `wingSuggestDecline` passing `profile_id` (`dating_profiles.id`) as `recipient_id` instead of `user_id` (`profiles.id`), which caused two bugs:
  - Suggested profiles were invisible in the dater's For You pool (the `get_discover_pool` join on `d.recipient_id = dp.user_id` never matched)
  - The wing pool exclusion filter didn't work, so a suggested card could reappear on the next page load for the winger

## Test plan
- [ ] Tapping ♥ opens the note modal; "Skip & Send" suggests with no note, "Add Note & Send" attaches the note
- [ ] After suggesting, the profile advances off the winger's queue and does not reappear on next page load
- [ ] Suggested profile appears in the dater's For You tab with the winger's note shown in the WingNoteSection

🤖 Generated with [Claude Code](https://claude.com/claude-code)