### PR TITLE
feat: wing discussion threads for winger-suggested profiles

### DIFF
--- a/app/(dater-tabs)/discover.tsx
+++ b/app/(dater-tabs)/discover.tsx
@@ -17,6 +17,7 @@ import {
   type DiscoverCard,
   type WingerTab,
 } from '@/queries/discover';
+import { getOrCreateWingDiscussion, useWingDiscussions } from '@/queries/wing-discussions';
 import { updateDatingProfile, useProfileData } from '@/queries/profiles';
 import { LargeHeader } from '@/components/ui/LargeHeader';
 import { TextTabBar } from '@/components/ui/TextTabBar';
@@ -24,6 +25,7 @@ import { PhotoRect } from '@/components/ui/PhotoRect';
 import { Pill } from '@/components/ui/Pill';
 import { PurpleButton } from '@/components/ui/PurpleButton';
 import { WingStack } from '@/components/ui/WingStack';
+import { WingDiscussionSheet } from '@/components/profile/WingDiscussionSheet';
 import { colors } from '@/constants/theme';
 import ScreenSuspense from '@/components/ui/ScreenSuspense';
 import { cardButtonShadow } from '@/lib/styles';
@@ -92,7 +94,15 @@ function DiscoverPausedScreen({
 
 // ── WingNoteSection ───────────────────────────────────────────────────────────
 
-function WingNoteSection({ card }: { card: DiscoverCard }) {
+function WingNoteSection({
+  card,
+  hasUnread,
+  onDiscuss,
+}: {
+  card: DiscoverCard;
+  hasUnread: boolean;
+  onDiscuss: () => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   const initial = card.suggester_name ? card.suggester_name[0].toUpperCase() : '?';
 
@@ -103,6 +113,14 @@ function WingNoteSection({ card }: { card: DiscoverCard }) {
         <Text className="text-sm font-semibold text-fg flex-1">
           {card.suggester_name} thinks you{"'"}d get along
         </Text>
+        <Pressable
+          className="flex-row items-center gap-1 px-2 py-1 rounded-full bg-accent-soft"
+          onPress={onDiscuss}
+          hitSlop={8}
+        >
+          {hasUnread && <View className="w-2 h-2 rounded-full bg-accent" />}
+          <Text className="text-xs font-semibold text-accent">Discuss</Text>
+        </Pressable>
       </View>
       <Text
         className="text-sm text-fg-muted"
@@ -122,7 +140,15 @@ function WingNoteSection({ card }: { card: DiscoverCard }) {
 
 // ── CardView ──────────────────────────────────────────────────────────────────
 
-function CardView({ card }: { card: DiscoverCard }) {
+function CardView({
+  card,
+  hasUnread,
+  onDiscuss,
+}: {
+  card: DiscoverCard;
+  hasUnread: boolean;
+  onDiscuss: () => void;
+}) {
   return (
     <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
       <View className="px-4">
@@ -133,7 +159,9 @@ function CardView({ card }: { card: DiscoverCard }) {
           {card.chosen_name}, {card.age}
         </Text>
         <Text className="text-sm text-fg-muted mt-1 mb-3">{card.city}</Text>
-        {card.wing_note != null && <WingNoteSection card={card} />}
+        {card.wing_note != null && (
+          <WingNoteSection card={card} hasUnread={hasUnread} onDiscuss={onDiscuss} />
+        )}
         {card.interests.length > 0 && (
           <View className="flex-row flex-wrap gap-2 mb-4">
             {card.interests.map((interest) => (
@@ -212,6 +240,16 @@ type DiscoverPoolProps = {
   wingerTabs: WingerTab[];
   tabs: string[];
   onDecrement: (() => void) | null;
+  unreadByDecisionId: Record<string, boolean>;
+};
+
+type DiscussionSheet = {
+  visible: boolean;
+  discussionId: string | null;
+  profileName: string;
+  profileAge: number;
+  profilePhotoUri: string | null;
+  wingerName: string;
 };
 
 function DiscoverPool({
@@ -220,6 +258,7 @@ function DiscoverPool({
   wingerTabs,
   tabs,
   onDecrement,
+  unreadByDecisionId,
 }: DiscoverPoolProps) {
   const isForYou = activeTabIndex === 1;
   const isAll = activeTabIndex === tabs.length - 1;
@@ -244,6 +283,33 @@ function DiscoverPool({
   const [matchCard, setMatchCard] = useState<DiscoverCard | null>(null);
   const card = pool[index] ?? null;
 
+  const [discussionSheet, setDiscussionSheet] = useState<DiscussionSheet>({
+    visible: false,
+    discussionId: null,
+    profileName: '',
+    profileAge: 0,
+    profilePhotoUri: null,
+    wingerName: '',
+  });
+
+  async function handleDiscuss(c: DiscoverCard) {
+    if (!c.decision_id || !c.suggested_by) return;
+    setDiscussionSheet({
+      visible: true,
+      discussionId: null,
+      profileName: c.chosen_name,
+      profileAge: c.age,
+      profilePhotoUri: c.first_photo,
+      wingerName: c.suggester_name ?? 'your winger',
+    });
+    const id = await getOrCreateWingDiscussion(c.decision_id, userId, c.suggested_by, c.user_id);
+    setDiscussionSheet((prev) => ({ ...prev, discussionId: id }));
+  }
+
+  function closeDiscussionSheet() {
+    setDiscussionSheet((prev) => ({ ...prev, visible: false }));
+  }
+
   async function handleLike() {
     if (!card) return;
     onDecrement?.();
@@ -264,7 +330,11 @@ function DiscoverPool({
     <>
       <View className="flex-1">
         {card != null ? (
-          <CardView card={card} />
+          <CardView
+            card={card}
+            hasUnread={card.decision_id != null && (unreadByDecisionId[card.decision_id] ?? false)}
+            onDiscuss={() => handleDiscuss(card)}
+          />
         ) : (
           <EmptyState tabIndex={activeTabIndex} wingerName={wingerTabs[activeTabIndex - 2]?.name} />
         )}
@@ -290,6 +360,19 @@ function DiscoverPool({
       )}
 
       {matchCard && <MatchOverlay card={matchCard} onDismiss={() => setMatchCard(null)} />}
+
+      <WingDiscussionSheet
+        visible={discussionSheet.visible}
+        onClose={closeDiscussionSheet}
+        discussionId={discussionSheet.discussionId}
+        currentUserId={userId}
+        otherParticipantName={discussionSheet.wingerName}
+        suggestedProfile={{
+          name: discussionSheet.profileName,
+          age: discussionSheet.profileAge,
+          photoUri: discussionSheet.profilePhotoUri,
+        }}
+      />
     </>
   );
 }
@@ -299,12 +382,20 @@ function DiscoverPool({
 function DiscoverContent({ userId }: { userId: string }) {
   const { data: wingerTabs } = useWingerTabs(userId);
   const { data: initialLikesYouCount } = useLikesYouCount(userId);
+  const { data: discussions } = useWingDiscussions(userId);
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const [likesYouDecrements, setLikesYouDecrements] = useState(0);
 
   const likesYouCount = Math.max(0, initialLikesYouCount - likesYouDecrements);
   // tabs: [Likes You, For You, ...wingers, All]
   const tabs = ['Likes You', 'For You', ...wingerTabs.map((w: WingerTab) => w.name), 'All'];
+
+  const unreadByDecisionId: Record<string, boolean> = {};
+  for (const d of discussions) {
+    const msgs = d.wing_discussion_messages ?? [];
+    const hasUnread = msgs.some((m) => !m.is_read && m.sender_id !== userId);
+    if (hasUnread) unreadByDecisionId[d.decision_id] = true;
+  }
 
   return (
     <SafeAreaView className="flex-1 bg-page">
@@ -331,6 +422,7 @@ function DiscoverContent({ userId }: { userId: string }) {
           wingerTabs={wingerTabs}
           tabs={tabs}
           onDecrement={activeTabIndex === 0 ? () => setLikesYouDecrements((d) => d + 1) : null}
+          unreadByDecisionId={unreadByDecisionId}
         />
       </Suspense>
     </SafeAreaView>

--- a/app/(dater-tabs)/profile/wingpeople/index.tsx
+++ b/app/(dater-tabs)/profile/wingpeople/index.tsx
@@ -21,6 +21,7 @@ import { NavHeader } from '@/components/ui/NavHeader';
 import { FaceAvatar } from '@/components/ui/FaceAvatar';
 import { PurpleButton } from '@/components/ui/PurpleButton';
 import { getInitials } from '@/components/profile/profile-helpers';
+import { PhotoRect } from '@/components/ui/PhotoRect';
 import { View, Text, TextInput, ScrollView, SafeAreaView, Pressable } from '@/lib/tw';
 import { useProfileData } from '@/queries/profiles';
 import {
@@ -30,6 +31,12 @@ import {
   declineInvitation,
   removeWingperson,
 } from '@/queries/contacts';
+import {
+  useWingDiscussions,
+  getOrCreateWingDiscussion,
+  type WingDiscussionRow,
+} from '@/queries/wing-discussions';
+import { WingDiscussionSheet } from '@/components/profile/WingDiscussionSheet';
 import { formatPhoneInput, toE164 } from '@/lib/phoneUtils';
 
 // ── Section header ─────────────────────────────────────────────────────────────
@@ -50,14 +57,16 @@ function SectionHeader({ title, right }: { title: string; right?: React.ReactNod
 interface ContentProps {
   userId: string;
   onOpenInvite: () => void;
+  onOpenDiscussion: (row: WingDiscussionRow) => void;
 }
 
-function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
+function WingpeopleContent({ userId, onOpenInvite, onOpenDiscussion }: ContentProps) {
   const router = useRouter();
   const {
     data: { wingpeople, invitations, wingingFor, sentInvitations, weeklyCounts },
     refetch,
   } = useWingpeopleData(userId);
+  const { data: discussions } = useWingDiscussions(userId);
 
   // ── Mutations ─────────────────────────────────────────────────────────────
 
@@ -243,7 +252,60 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
         })
       )}
 
-      {/* ── Section 4: You're Winging For ──────────────────────────────── */}
+      {/* ── Section 4: Discussions ──────────────────────────────────────── */}
+      {discussions.length > 0 && (
+        <>
+          <SectionHeader title="Discussions" />
+          {discussions.map((d) => {
+            const suggested = d.suggested_profile as {
+              id: string;
+              chosen_name: string | null;
+              avatar_url: string | null;
+            } | null;
+            const other =
+              d.winger_id === userId
+                ? (d.dater as {
+                    id: string;
+                    chosen_name: string | null;
+                    avatar_url: string | null;
+                  } | null)
+                : (d.winger as {
+                    id: string;
+                    chosen_name: string | null;
+                    avatar_url: string | null;
+                  } | null);
+            const msgs = d.wing_discussion_messages ?? [];
+            const lastMsg = msgs[0];
+            const hasUnread = msgs.some((m) => !m.is_read && m.sender_id !== userId);
+            const otherName = other?.chosen_name ?? 'Unknown';
+            const suggestedName = suggested?.chosen_name ?? 'Unknown';
+            return (
+              <Pressable
+                key={d.id}
+                className="flex-row items-center px-5 py-3 gap-3 bg-white"
+                style={{
+                  borderBottomWidth: StyleSheet.hairlineWidth,
+                  borderBottomColor: colors.divider,
+                }}
+                onPress={() => onOpenDiscussion(d)}
+              >
+                <View style={{ width: 40, height: 40, borderRadius: 8, overflow: 'hidden' }}>
+                  <PhotoRect uri={suggested?.avatar_url ?? null} ratio={1} />
+                </View>
+                <View className="flex-1">
+                  <Text className="text-sm font-semibold text-fg">{suggestedName}</Text>
+                  <Text className="text-xs text-fg-muted mt-0.5" numberOfLines={1}>
+                    {lastMsg ? lastMsg.body : `with ${otherName}`}
+                  </Text>
+                </View>
+                {hasUnread && <View className="w-2.5 h-2.5 rounded-full bg-accent" />}
+              </Pressable>
+            );
+          })}
+        </>
+      )}
+
+      {/* ── Section 5: You're Winging For ──────────────────────────────── */}
       <SectionHeader title="You're Winging For" />
 
       {wingingFor.length === 0 ? (
@@ -302,6 +364,15 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
 
 type InviteForm = { phone: string };
 
+type DiscussionSheet = {
+  visible: boolean;
+  discussionId: string | null;
+  profileName: string;
+  profileAge: number;
+  profilePhotoUri: string | null;
+  wingerName: string;
+};
+
 export default function WingpeopleScreen() {
   const router = useRouter();
   const { userId } = useAuth();
@@ -312,6 +383,49 @@ export default function WingpeopleScreen() {
   } = useProfileData(userId);
 
   const [inviteVisible, setInviteVisible] = useState(false);
+  const [discussionSheet, setDiscussionSheet] = useState<DiscussionSheet>({
+    visible: false,
+    discussionId: null,
+    profileName: '',
+    profileAge: 0,
+    profilePhotoUri: null,
+    wingerName: '',
+  });
+
+  async function handleOpenDiscussion(row: WingDiscussionRow) {
+    const suggested = row.suggested_profile as {
+      id: string;
+      chosen_name: string | null;
+      avatar_url: string | null;
+    } | null;
+    const other =
+      row.winger_id === userId
+        ? (row.dater as {
+            id: string;
+            chosen_name: string | null;
+            avatar_url: string | null;
+          } | null)
+        : (row.winger as {
+            id: string;
+            chosen_name: string | null;
+            avatar_url: string | null;
+          } | null);
+    setDiscussionSheet({
+      visible: true,
+      discussionId: null,
+      profileName: suggested?.chosen_name ?? 'Unknown',
+      profileAge: 0,
+      profilePhotoUri: suggested?.avatar_url ?? null,
+      wingerName: other?.chosen_name ?? 'your winger',
+    });
+    const id = await getOrCreateWingDiscussion(
+      row.decision_id,
+      row.dater_id,
+      row.winger_id,
+      (row.suggested_profile as any)?.id ?? ''
+    );
+    setDiscussionSheet((prev) => ({ ...prev, discussionId: id }));
+  }
 
   const {
     control,
@@ -379,7 +493,11 @@ export default function WingpeopleScreen() {
           </View>
         }
       >
-        <WingpeopleContent userId={userId} onOpenInvite={onOpenInvite} />
+        <WingpeopleContent
+          userId={userId}
+          onOpenInvite={onOpenInvite}
+          onOpenDiscussion={handleOpenDiscussion}
+        />
       </Suspense>
 
       {/* ── Invite Bottom Sheet ──────────────────────────────────────────────── */}
@@ -442,6 +560,19 @@ export default function WingpeopleScreen() {
           </KeyboardAvoidingView>
         </View>
       </Modal>
+
+      <WingDiscussionSheet
+        visible={discussionSheet.visible}
+        onClose={() => setDiscussionSheet((prev) => ({ ...prev, visible: false }))}
+        discussionId={discussionSheet.discussionId}
+        currentUserId={userId}
+        otherParticipantName={discussionSheet.wingerName}
+        suggestedProfile={{
+          name: discussionSheet.profileName,
+          age: discussionSheet.profileAge,
+          photoUri: discussionSheet.profilePhotoUri,
+        }}
+      />
     </SafeAreaView>
   );
 }

--- a/app/(winger)/wingpeople/index.tsx
+++ b/app/(winger)/wingpeople/index.tsx
@@ -21,6 +21,7 @@ import { NavHeader } from '@/components/ui/NavHeader';
 import { FaceAvatar } from '@/components/ui/FaceAvatar';
 import { PurpleButton } from '@/components/ui/PurpleButton';
 import { getInitials } from '@/components/profile/profile-helpers';
+import { PhotoRect } from '@/components/ui/PhotoRect';
 import { View, Text, TextInput, ScrollView, SafeAreaView, Pressable } from '@/lib/tw';
 import { useProfileData } from '@/queries/profiles';
 import {
@@ -30,6 +31,12 @@ import {
   declineInvitation,
   removeWingperson,
 } from '@/queries/contacts';
+import {
+  useWingDiscussions,
+  getOrCreateWingDiscussion,
+  type WingDiscussionRow,
+} from '@/queries/wing-discussions';
+import { WingDiscussionSheet } from '@/components/profile/WingDiscussionSheet';
 import { formatPhoneInput, toE164 } from '@/lib/phoneUtils';
 
 // ── Section header ─────────────────────────────────────────────────────────────
@@ -50,14 +57,16 @@ function SectionHeader({ title, right }: { title: string; right?: React.ReactNod
 interface ContentProps {
   userId: string;
   onOpenInvite: () => void;
+  onOpenDiscussion: (row: WingDiscussionRow) => void;
 }
 
-function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
+function WingpeopleContent({ userId, onOpenInvite, onOpenDiscussion }: ContentProps) {
   const router = useRouter();
   const {
     data: { wingpeople, invitations, wingingFor, sentInvitations, weeklyCounts },
     refetch,
   } = useWingpeopleData(userId);
+  const { data: discussions } = useWingDiscussions(userId);
 
   // ── Mutations ─────────────────────────────────────────────────────────────
 
@@ -243,7 +252,60 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
         })
       )}
 
-      {/* ── Section 4: You're Winging For ──────────────────────────────── */}
+      {/* ── Section 4: Discussions ──────────────────────────────────────── */}
+      {discussions.length > 0 && (
+        <>
+          <SectionHeader title="Discussions" />
+          {discussions.map((d) => {
+            const suggested = d.suggested_profile as {
+              id: string;
+              chosen_name: string | null;
+              avatar_url: string | null;
+            } | null;
+            const other =
+              d.winger_id === userId
+                ? (d.dater as {
+                    id: string;
+                    chosen_name: string | null;
+                    avatar_url: string | null;
+                  } | null)
+                : (d.winger as {
+                    id: string;
+                    chosen_name: string | null;
+                    avatar_url: string | null;
+                  } | null);
+            const msgs = d.wing_discussion_messages ?? [];
+            const lastMsg = msgs[0];
+            const hasUnread = msgs.some((m) => !m.is_read && m.sender_id !== userId);
+            const otherName = other?.chosen_name ?? 'Unknown';
+            const suggestedName = suggested?.chosen_name ?? 'Unknown';
+            return (
+              <Pressable
+                key={d.id}
+                className="flex-row items-center px-5 py-3 gap-3 bg-white"
+                style={{
+                  borderBottomWidth: StyleSheet.hairlineWidth,
+                  borderBottomColor: colors.divider,
+                }}
+                onPress={() => onOpenDiscussion(d)}
+              >
+                <View style={{ width: 40, height: 40, borderRadius: 8, overflow: 'hidden' }}>
+                  <PhotoRect uri={suggested?.avatar_url ?? null} ratio={1} />
+                </View>
+                <View className="flex-1">
+                  <Text className="text-sm font-semibold text-fg">{suggestedName}</Text>
+                  <Text className="text-xs text-fg-muted mt-0.5" numberOfLines={1}>
+                    {lastMsg ? lastMsg.body : `with ${otherName}`}
+                  </Text>
+                </View>
+                {hasUnread && <View className="w-2.5 h-2.5 rounded-full bg-accent" />}
+              </Pressable>
+            );
+          })}
+        </>
+      )}
+
+      {/* ── Section 5: You're Winging For ──────────────────────────────── */}
       <SectionHeader title="You're Winging For" />
 
       {wingingFor.length === 0 ? (
@@ -298,6 +360,15 @@ function WingpeopleContent({ userId, onOpenInvite }: ContentProps) {
 
 type InviteForm = { phone: string };
 
+type DiscussionSheet = {
+  visible: boolean;
+  discussionId: string | null;
+  profileName: string;
+  profileAge: number;
+  profilePhotoUri: string | null;
+  wingerName: string;
+};
+
 export default function WingpeopleScreen() {
   const router = useRouter();
   const { userId } = useAuth();
@@ -308,6 +379,49 @@ export default function WingpeopleScreen() {
   } = useProfileData(userId);
 
   const [inviteVisible, setInviteVisible] = useState(false);
+  const [discussionSheet, setDiscussionSheet] = useState<DiscussionSheet>({
+    visible: false,
+    discussionId: null,
+    profileName: '',
+    profileAge: 0,
+    profilePhotoUri: null,
+    wingerName: '',
+  });
+
+  async function handleOpenDiscussion(row: WingDiscussionRow) {
+    const suggested = row.suggested_profile as {
+      id: string;
+      chosen_name: string | null;
+      avatar_url: string | null;
+    } | null;
+    const other =
+      row.winger_id === userId
+        ? (row.dater as {
+            id: string;
+            chosen_name: string | null;
+            avatar_url: string | null;
+          } | null)
+        : (row.winger as {
+            id: string;
+            chosen_name: string | null;
+            avatar_url: string | null;
+          } | null);
+    setDiscussionSheet({
+      visible: true,
+      discussionId: null,
+      profileName: suggested?.chosen_name ?? 'Unknown',
+      profileAge: 0,
+      profilePhotoUri: suggested?.avatar_url ?? null,
+      wingerName: other?.chosen_name ?? 'Unknown',
+    });
+    const id = await getOrCreateWingDiscussion(
+      row.decision_id,
+      row.dater_id,
+      row.winger_id,
+      (row.suggested_profile as any)?.id ?? ''
+    );
+    setDiscussionSheet((prev) => ({ ...prev, discussionId: id }));
+  }
 
   const {
     control,
@@ -375,7 +489,11 @@ export default function WingpeopleScreen() {
           </View>
         }
       >
-        <WingpeopleContent userId={userId} onOpenInvite={onOpenInvite} />
+        <WingpeopleContent
+          userId={userId}
+          onOpenInvite={onOpenInvite}
+          onOpenDiscussion={handleOpenDiscussion}
+        />
       </Suspense>
 
       {/* ── Invite Bottom Sheet ──────────────────────────────────────────────── */}
@@ -438,6 +556,19 @@ export default function WingpeopleScreen() {
           </KeyboardAvoidingView>
         </View>
       </Modal>
+
+      <WingDiscussionSheet
+        visible={discussionSheet.visible}
+        onClose={() => setDiscussionSheet((prev) => ({ ...prev, visible: false }))}
+        discussionId={discussionSheet.discussionId}
+        currentUserId={userId}
+        otherParticipantName={discussionSheet.wingerName}
+        suggestedProfile={{
+          name: discussionSheet.profileName,
+          age: discussionSheet.profileAge,
+          photoUri: discussionSheet.profilePhotoUri,
+        }}
+      />
     </SafeAreaView>
   );
 }

--- a/components/profile/WingDiscussionSheet.tsx
+++ b/components/profile/WingDiscussionSheet.tsx
@@ -1,0 +1,272 @@
+import { useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Controller, useForm } from 'react-hook-form';
+
+import { useWingDiscussion } from '@/hooks/use-wing-discussion';
+import { PhotoRect } from '@/components/ui/PhotoRect';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { colors } from '@/constants/theme';
+import { View, Text, TextInput, Pressable } from '@/lib/tw';
+import { cn } from '@/lib/cn';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatTimestamp(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+// ── MessageBubble ─────────────────────────────────────────────────────────────
+
+type MessageBubbleProps = {
+  body: string;
+  isMine: boolean;
+  createdAt: string;
+  isOptimistic: boolean;
+};
+
+function MessageBubble({ body, isMine, createdAt, isOptimistic }: MessageBubbleProps) {
+  const [showTime, setShowTime] = useState(false);
+
+  return (
+    <View
+      className={cn('my-0.5 max-w-[78%]', isMine ? 'self-end items-end' : 'self-start items-start')}
+    >
+      <Pressable
+        onPress={() => setShowTime((v) => !v)}
+        className={cn(
+          'rounded-[18px] py-[9px] px-3.5',
+          isMine ? 'bg-accent-muted rounded-br-[4px]' : 'bg-white rounded-bl-[4px]',
+          isOptimistic && 'opacity-65'
+        )}
+      >
+        <Text className="text-sm leading-[21px] text-fg">{body}</Text>
+      </Pressable>
+      {showTime && (
+        <Text
+          className={cn('text-xs text-fg-ghost mt-[3px] mx-1', isMine ? 'text-right' : 'text-left')}
+        >
+          {formatTimestamp(createdAt)}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+// ── Sheet content ─────────────────────────────────────────────────────────────
+
+type SheetContentProps = {
+  discussionId: string;
+  currentUserId: string;
+  otherParticipantName: string;
+  suggestedProfile: { name: string; age: number; photoUri: string | null };
+  onClose: () => void;
+};
+
+function SheetContent({
+  discussionId,
+  currentUserId,
+  otherParticipantName,
+  suggestedProfile,
+  onClose,
+}: SheetContentProps) {
+  const insets = useSafeAreaInsets();
+  const listRef = useRef<FlatList>(null);
+  const { messages, loading, error, send, reload } = useWingDiscussion(discussionId);
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { isSubmitting },
+  } = useForm<{ message: string }>({
+    mode: 'onChange',
+    defaultValues: { message: '' },
+  });
+
+  const messageValue = watch('message');
+
+  const onSubmit = handleSubmit(async ({ message }) => {
+    const text = message.trim();
+    if (!text) return;
+    reset();
+    await send(text);
+    setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 100);
+  });
+
+  return (
+    <View className="flex-1 bg-page">
+      {/* Header */}
+      <View
+        className="flex-row items-center px-4 gap-3 bg-white"
+        style={{
+          paddingTop: insets.top + 12,
+          paddingBottom: 12,
+          borderBottomWidth: StyleSheet.hairlineWidth,
+          borderBottomColor: colors.divider,
+        }}
+      >
+        <View style={{ width: 40, height: 40, borderRadius: 8, overflow: 'hidden' }}>
+          <PhotoRect uri={suggestedProfile.photoUri} ratio={1} />
+        </View>
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-fg">
+            {suggestedProfile.name}, {suggestedProfile.age}
+          </Text>
+          <Text className="text-xs text-fg-muted mt-0.5">with {otherParticipantName}</Text>
+        </View>
+        <Pressable
+          className="w-8 h-8 rounded-full bg-surface items-center justify-center"
+          onPress={onClose}
+          hitSlop={8}
+        >
+          <IconSymbol name="xmark" size={16} color={colors.inkMid} />
+        </Pressable>
+      </View>
+
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={0}
+      >
+        {loading ? (
+          <View className="flex-1 items-center justify-center">
+            <ActivityIndicator color={colors.purple} />
+          </View>
+        ) : error != null ? (
+          <View className="flex-1 items-center justify-center p-8 gap-3">
+            <Text className="text-sm text-fg-muted text-center">{error}</Text>
+            <Pressable className="py-2 px-4" onPress={reload}>
+              <Text className="text-sm font-semibold text-accent">Try again</Text>
+            </Pressable>
+          </View>
+        ) : (
+          <FlatList
+            ref={listRef}
+            data={messages}
+            keyExtractor={(item) => item.id}
+            contentContainerStyle={{
+              flexGrow: 1,
+              paddingVertical: 12,
+              paddingHorizontal: 12,
+              gap: 4,
+            }}
+            onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: false })}
+            ListEmptyComponent={
+              <View className="flex-1 items-center justify-center p-10">
+                <Text className="text-sm text-fg-muted text-center">
+                  Ask {otherParticipantName} about {suggestedProfile.name}.
+                </Text>
+              </View>
+            }
+            renderItem={({ item }) => (
+              <MessageBubble
+                body={item.body}
+                isMine={item.sender_id === currentUserId}
+                createdAt={item.created_at}
+                isOptimistic={item.id.startsWith('temp-')}
+              />
+            )}
+          />
+        )}
+
+        {/* Input bar */}
+        <View
+          className="flex-row items-end px-3 py-2 bg-white gap-2"
+          style={{
+            paddingBottom: insets.bottom + 8,
+            borderTopWidth: StyleSheet.hairlineWidth,
+            borderTopColor: colors.divider,
+          }}
+        >
+          <Controller
+            control={control}
+            name="message"
+            render={({ field: { value, onChange } }) => (
+              <TextInput
+                className="flex-1 bg-surface rounded-2xl px-4 py-[9px] text-sm text-fg"
+                style={{ maxHeight: 120, lineHeight: 20 }}
+                value={value}
+                onChangeText={onChange}
+                placeholder="Message…"
+                placeholderTextColor={colors.inkGhost}
+                multiline
+                maxLength={1000}
+                returnKeyType="send"
+                blurOnSubmit={false}
+                onSubmitEditing={onSubmit}
+              />
+            )}
+          />
+          <Pressable
+            className={cn(
+              'w-9 h-9 rounded-[18px] bg-accent items-center justify-center',
+              (!messageValue.trim() || isSubmitting) && 'opacity-40'
+            )}
+            onPress={onSubmit}
+            disabled={!messageValue.trim() || isSubmitting}
+            hitSlop={8}
+          >
+            {isSubmitting ? (
+              <ActivityIndicator color={colors.white} size="small" />
+            ) : (
+              <IconSymbol name="arrow.up" size={18} color={colors.white} />
+            )}
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+// ── WingDiscussionSheet ───────────────────────────────────────────────────────
+
+export type WingDiscussionSheetProps = {
+  visible: boolean;
+  onClose: () => void;
+  discussionId: string | null;
+  currentUserId: string;
+  otherParticipantName: string;
+  suggestedProfile: { name: string; age: number; photoUri: string | null };
+};
+
+export function WingDiscussionSheet({
+  visible,
+  onClose,
+  discussionId,
+  currentUserId,
+  otherParticipantName,
+  suggestedProfile,
+}: WingDiscussionSheetProps) {
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      {discussionId != null ? (
+        <SheetContent
+          discussionId={discussionId}
+          currentUserId={currentUserId}
+          otherParticipantName={otherParticipantName}
+          suggestedProfile={suggestedProfile}
+          onClose={onClose}
+        />
+      ) : (
+        <View className="flex-1 items-center justify-center bg-page">
+          <ActivityIndicator color={colors.purple} />
+        </View>
+      )}
+    </Modal>
+  );
+}

--- a/hooks/use-wing-discussion.ts
+++ b/hooks/use-wing-discussion.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/context/auth';
+import {
+  getWingDiscussionMessages,
+  markWingDiscussionRead,
+  sendWingDiscussionMessage,
+  subscribeToWingDiscussionMessages,
+  type WingDiscussionMessage,
+} from '@/queries/wing-discussions';
+
+export function useWingDiscussion(discussionId: string) {
+  const { userId } = useAuth();
+
+  const [messages, setMessages] = useState<WingDiscussionMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const optimisticIds = useRef<Set<string>>(new Set());
+
+  const load = useCallback(async () => {
+    if (!discussionId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const { data, error: err } = await getWingDiscussionMessages(discussionId);
+      if (err) throw err;
+      setMessages(data ?? []);
+      await markWingDiscussionRead(discussionId, userId);
+    } catch {
+      setError("Couldn't load messages.");
+    } finally {
+      setLoading(false);
+    }
+  }, [discussionId, userId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Acceptable exception: mount-only guard for a genuine external event.
+  useEffect(() => {
+    if (!discussionId) return;
+
+    const channel = subscribeToWingDiscussionMessages(discussionId, (payload) => {
+      const incoming = payload.new as WingDiscussionMessage;
+
+      setMessages((prev) => {
+        if (incoming.sender_id === userId && optimisticIds.current.size > 0) {
+          const firstOptimistic = [...optimisticIds.current][0];
+          optimisticIds.current.delete(firstOptimistic);
+          return prev.map((m) => (m.id === firstOptimistic ? incoming : m));
+        }
+        if (prev.some((m) => m.id === incoming.id)) return prev;
+        return [...prev, incoming];
+      });
+
+      if (incoming.sender_id !== userId) {
+        markWingDiscussionRead(discussionId, userId);
+      }
+    });
+
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [discussionId, userId]);
+
+  const send = useCallback(
+    async (body: string) => {
+      if (!body.trim()) return;
+
+      const tempId = `temp-${Date.now()}`;
+      optimisticIds.current.add(tempId);
+
+      const optimistic: WingDiscussionMessage = {
+        id: tempId,
+        discussion_id: discussionId,
+        sender_id: userId,
+        body: body.trim(),
+        is_read: false,
+        created_at: new Date().toISOString(),
+        sender: { id: userId, chosen_name: null },
+      };
+
+      setMessages((prev) => [...prev, optimistic]);
+
+      const { error: err } = await sendWingDiscussionMessage(discussionId, userId, body.trim());
+      if (err) {
+        optimisticIds.current.delete(tempId);
+        setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      }
+    },
+    [discussionId, userId]
+  );
+
+  return { messages, loading, error, send, reload: load };
+}

--- a/queries/discover.ts
+++ b/queries/discover.ts
@@ -19,6 +19,7 @@ export type DiscoverCard = {
   wing_note: string | null;
   suggested_by: string | null;
   suggester_name: string | null;
+  decision_id: string | null;
 };
 
 export type WingCard = Omit<DiscoverCard, 'wing_note' | 'suggested_by' | 'suggester_name'>;

--- a/queries/index.ts
+++ b/queries/index.ts
@@ -6,3 +6,4 @@ export * from './messages';
 export * from './photos';
 export * from './profiles';
 export * from './prompts';
+export * from './wing-discussions';

--- a/queries/wing-discussions.ts
+++ b/queries/wing-discussions.ts
@@ -1,0 +1,134 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import type { RealtimeChannel, RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
+
+type WingDiscussionMessageRow = Database['public']['Tables']['wing_discussion_messages']['Row'];
+
+// ── Read ──────────────────────────────────────────────────────────────────────
+
+export function getWingDiscussionMessages(discussionId: string, limit = 100) {
+  return supabase
+    .from('wing_discussion_messages')
+    .select('*, sender:profiles!wing_discussion_messages_sender_id_fkey(id, chosen_name)')
+    .eq('discussion_id', discussionId)
+    .order('created_at', { ascending: true })
+    .limit(limit);
+}
+
+export type WingDiscussionMessage = NonNullable<
+  Awaited<ReturnType<typeof getWingDiscussionMessages>>['data']
+>[number];
+
+/**
+ * Returns all active discussions for a user (as dater or winger), with the
+ * suggested profile's name/photo, the other participant's name, and unread count.
+ */
+export function getWingDiscussions(userId: string) {
+  return supabase
+    .from('wing_discussions')
+    .select(
+      `
+      id, decision_id, dater_id, winger_id, created_at,
+      suggested_profile:profiles!wing_discussions_suggested_profile_id_fkey (id, chosen_name, avatar_url),
+      dater:profiles!wing_discussions_dater_id_fkey (id, chosen_name, avatar_url),
+      winger:profiles!wing_discussions_winger_id_fkey (id, chosen_name, avatar_url),
+      wing_discussion_messages (id, body, created_at, sender_id, is_read)
+    `
+    )
+    .or(`dater_id.eq.${userId},winger_id.eq.${userId}`)
+    .order('created_at', { referencedTable: 'wing_discussion_messages', ascending: false })
+    .limit(1, { referencedTable: 'wing_discussion_messages' })
+    .order('created_at', { ascending: false });
+}
+
+export type WingDiscussionRow = NonNullable<
+  Awaited<ReturnType<typeof getWingDiscussions>>['data']
+>[number];
+
+export function useWingDiscussions(userId: string) {
+  return useSuspenseQuery({
+    queryKey: [getWingDiscussions, userId],
+    queryFn: async () => {
+      const { data, error } = await getWingDiscussions(userId);
+      if (error) throw error;
+      return data ?? [];
+    },
+    staleTime: 30_000,
+  });
+}
+
+// ── Write ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Upsert a discussion thread for a suggestion. Returns the discussion id.
+ * Safe to call multiple times — the unique constraint on decision_id ensures
+ * only one thread per suggestion is ever created.
+ */
+export async function getOrCreateWingDiscussion(
+  decisionId: string,
+  daterId: string,
+  wingerId: string,
+  suggestedProfileId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('wing_discussions')
+    .upsert(
+      {
+        decision_id: decisionId,
+        dater_id: daterId,
+        winger_id: wingerId,
+        suggested_profile_id: suggestedProfileId,
+      },
+      { onConflict: 'decision_id', ignoreDuplicates: false }
+    )
+    .select('id')
+    .single();
+
+  if (error) {
+    // If the upsert failed (e.g. duplicate key race), fall back to a select
+    const { data: existing } = await supabase
+      .from('wing_discussions')
+      .select('id')
+      .eq('decision_id', decisionId)
+      .single();
+    return existing?.id ?? null;
+  }
+  return data?.id ?? null;
+}
+
+export function sendWingDiscussionMessage(discussionId: string, senderId: string, body: string) {
+  return supabase
+    .from('wing_discussion_messages')
+    .insert({ discussion_id: discussionId, sender_id: senderId, body });
+}
+
+export function markWingDiscussionRead(discussionId: string, viewerId: string) {
+  return supabase
+    .from('wing_discussion_messages')
+    .update({ is_read: true })
+    .eq('discussion_id', discussionId)
+    .eq('is_read', false)
+    .neq('sender_id', viewerId);
+}
+
+// ── Real-time ─────────────────────────────────────────────────────────────────
+
+export function subscribeToWingDiscussionMessages(
+  discussionId: string,
+  onInsert: (payload: RealtimePostgresChangesPayload<WingDiscussionMessageRow>) => void
+): RealtimeChannel {
+  return supabase
+    .channel(`wing-discussion:${discussionId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'wing_discussion_messages',
+        filter: `discussion_id=eq.${discussionId}`,
+      },
+      onInsert
+    )
+    .subscribe();
+}

--- a/scripts/seed-local.ts
+++ b/scripts/seed-local.ts
@@ -996,6 +996,129 @@ async function seedWingerPromptResponses(devUserId: string, wingerIds: string[])
   console.log(`  ${inserted} winger responses inserted, ${skipped} skipped`);
 }
 
+// These profiles are seeded purely to be winger-suggested to the dev user.
+// They do NOT appear in seedDecisions (they haven't liked the dev user),
+// so they show up in the For You tab rather than Likes You.
+const SUGGESTION_WOMEN: { first: string; last: string }[] = [
+  { first: 'Zoe', last: 'Bennett' },
+  { first: 'Maya', last: 'Foster' },
+  { first: 'Aria', last: 'Hughes' },
+  { first: 'Nova', last: 'Price' },
+  { first: 'Iris', last: 'Coleman' },
+];
+
+const WINGER_SUGGESTION_NOTES: string[] = [
+  "She's exactly your vibe — you'd have so much to talk about.",
+  'Trust me on this one. You two would really click.',
+  "Okay hear me out — I think you'd genuinely like them.",
+  "They're hilarious and low-key brilliant. Just saying.",
+  "Met them at a party last month. You'd get along great.",
+];
+
+async function seedWingerSuggestions(devUserId: string): Promise<void> {
+  const { data: listData } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+
+  const wingerEmails = SAMPLE_WINGERS.map(
+    (w) => `winger.${w.first.toLowerCase()}.${w.last.toLowerCase()}@seed.orbit.test`
+  );
+  const wingers = listData.users.filter((u) => u.email && wingerEmails.includes(u.email));
+
+  if (wingers.length === 0) {
+    console.log('  no wingers found — skipping suggestions');
+    return;
+  }
+
+  // Ensure each suggestion-only profile exists
+  let photoIdx = 50;
+  for (const p of SUGGESTION_WOMEN) {
+    const email = `suggest.${p.first.toLowerCase()}.${p.last.toLowerCase()}@seed.orbit.test`;
+    const existing = listData.users.find((u) => u.email === email);
+    if (!existing) {
+      const { data: authData, error: authError } = await supabase.auth.admin.createUser({
+        email,
+        password: 'Orbit123!',
+        email_confirm: true,
+      });
+      if (authError)
+        throw new Error(`suggestion profile ${p.first} auth error: ${authError.message}`);
+      const uid = authData.user.id;
+      await supabase
+        .from('profiles')
+        .update({
+          chosen_name: p.first,
+          last_name: p.last,
+          date_of_birth: randomDob(24, 32),
+          gender: 'Female',
+          role: 'dater',
+          phone_number: `+1555${String(9000000 + photoIdx * 13).slice(0, 7)}`,
+        })
+        .eq('id', uid);
+      const { data: dp } = await supabase
+        .from('dating_profiles')
+        .insert({
+          user_id: uid,
+          bio: pick(BIOS),
+          interested_gender: ['Male'],
+          age_from: 22,
+          age_to: 38,
+          religion: pick(RELIGIONS),
+          interests: pickN(ALL_INTERESTS, 4),
+          city: 'New York',
+          is_active: true,
+          dating_status: 'open',
+        })
+        .select('id')
+        .single();
+      if (dp) {
+        await supabase.from('profile_photos').insert({
+          dating_profile_id: dp.id,
+          storage_url: `https://randomuser.me/api/portraits/women/${photoIdx % 99}.jpg`,
+          display_order: 0,
+          approved_at: new Date().toISOString(),
+        });
+      }
+    }
+    photoIdx++;
+  }
+
+  // Re-fetch users after possible creation
+  const { data: refreshed } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+  const suggestionEmails = SUGGESTION_WOMEN.map(
+    (p) => `suggest.${p.first.toLowerCase()}.${p.last.toLowerCase()}@seed.orbit.test`
+  );
+  const suggestedUsers = (refreshed?.users ?? []).filter(
+    (u) => u.email && suggestionEmails.includes(u.email)
+  );
+
+  let count = 0;
+  for (let i = 0; i < suggestedUsers.length; i++) {
+    const suggested = suggestedUsers[i];
+    const winger = wingers[i % wingers.length];
+    const note = WINGER_SUGGESTION_NOTES[i % WINGER_SUGGESTION_NOTES.length];
+
+    const { data: existing } = await supabase
+      .from('decisions')
+      .select('id')
+      .eq('actor_id', devUserId)
+      .eq('recipient_id', suggested.id)
+      .maybeSingle();
+
+    if (existing) continue;
+
+    const { error } = await supabase.from('decisions').insert({
+      actor_id: devUserId,
+      recipient_id: suggested.id,
+      decision: null,
+      suggested_by: winger.id,
+      note,
+    });
+    if (error) throw new Error(`suggestion error: ${error.message}`);
+    count++;
+  }
+
+  console.log(`  ${count} winger suggestions seeded for dev user`);
+}
+
 async function main(): Promise<void> {
   console.log('Setting up local dev database…\n');
 
@@ -1030,6 +1153,9 @@ async function main(): Promise<void> {
 
   console.log('\nSeeding winger prompt responses on dev user…');
   await seedWingerPromptResponses(devUserId, wingerIds);
+
+  console.log('\nSeeding winger suggestions…');
+  await seedWingerSuggestions(devUserId);
 
   console.log('\nDone. Local DB is ready. Sign in as dev@local.test / devpassword');
 }

--- a/supabase/functions/notify-wing-discussion/index.ts
+++ b/supabase/functions/notify-wing-discussion/index.ts
@@ -1,0 +1,90 @@
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+interface WebhookPayload {
+  type: 'INSERT' | 'UPDATE' | 'DELETE';
+  table: string;
+  schema: 'public';
+  record: Record<string, unknown>;
+  old_record: Record<string, unknown> | null;
+}
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+async function sendPush(token: string, title: string, body: string) {
+  const res = await fetch('https://exp.host/--/api/v2/push/send', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ to: token, title, body }),
+  });
+  if (!res.ok) {
+    console.error('Expo push failed:', await res.text());
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  let payload: WebhookPayload;
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { record } = payload;
+  const discussion_id = record.discussion_id as string;
+  const sender_id = record.sender_id as string;
+  const msgBody = record.body as string;
+
+  if (!discussion_id || !sender_id || !msgBody) {
+    return json({ error: 'discussion_id, sender_id, and body required' }, 400);
+  }
+
+  const admin = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  );
+
+  const { data: discussion } = await admin
+    .from('wing_discussions')
+    .select('dater_id, winger_id')
+    .eq('id', discussion_id)
+    .single();
+
+  if (!discussion) return json({ ok: true }, 200);
+
+  const recipient_id =
+    discussion.dater_id === sender_id ? discussion.winger_id : discussion.dater_id;
+
+  if (recipient_id === sender_id) return json({ ok: true }, 200);
+
+  const { data: profiles } = await admin
+    .from('profiles')
+    .select('id, push_token, chosen_name')
+    .in('id', [sender_id, recipient_id]);
+
+  if (!profiles) return json({ ok: true }, 200);
+
+  const sender = profiles.find((p) => p.id === sender_id);
+  const recipient = profiles.find((p) => p.id === recipient_id);
+
+  if (!recipient?.push_token) return json({ ok: true }, 200);
+
+  const senderName = sender?.chosen_name ?? 'Someone';
+  const preview = msgBody.length > 80 ? msgBody.slice(0, 77) + '…' : msgBody;
+
+  await sendPush(recipient.push_token, `${senderName} about a profile`, preview);
+
+  return json({ ok: true }, 200);
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/migrations/20260419000000_wing_discussions.sql
+++ b/supabase/migrations/20260419000000_wing_discussions.sql
@@ -1,0 +1,199 @@
+-- Wing Discussions: per-suggestion chat threads between dater and winger.
+-- Also adds decision_id to get_discover_pool so the client can open/create
+-- a discussion thread from the discover card.
+
+-- ── 1. Tables ──────────────────────────────────────────────────────────────────
+
+create table public.wing_discussions (
+  id                   uuid primary key default gen_random_uuid(),
+  decision_id          uuid not null unique references public.decisions(id) on delete cascade,
+  dater_id             uuid not null references public.profiles(id),
+  winger_id            uuid not null references public.profiles(id),
+  suggested_profile_id uuid not null references public.profiles(id),
+  created_at           timestamptz not null default now()
+);
+
+create table public.wing_discussion_messages (
+  id            uuid primary key default gen_random_uuid(),
+  discussion_id uuid not null references public.wing_discussions(id) on delete cascade,
+  sender_id     uuid not null references public.profiles(id),
+  body          text not null,
+  is_read       boolean not null default false,
+  created_at    timestamptz not null default now()
+);
+
+-- ── 2. RLS ─────────────────────────────────────────────────────────────────────
+
+alter table public.wing_discussions enable row level security;
+alter table public.wing_discussion_messages enable row level security;
+
+create policy "participants can read discussions"
+  on public.wing_discussions for select
+  using (auth.uid() = dater_id or auth.uid() = winger_id);
+
+create policy "participants can insert discussions"
+  on public.wing_discussions for insert
+  with check (auth.uid() = dater_id or auth.uid() = winger_id);
+
+create policy "participants can read messages"
+  on public.wing_discussion_messages for select
+  using (
+    exists (
+      select 1 from public.wing_discussions d
+      where d.id = discussion_id
+        and (d.dater_id = auth.uid() or d.winger_id = auth.uid())
+    )
+  );
+
+create policy "participants can insert messages"
+  on public.wing_discussion_messages for insert
+  with check (
+    sender_id = auth.uid()
+    and exists (
+      select 1 from public.wing_discussions d
+      where d.id = discussion_id
+        and (d.dater_id = auth.uid() or d.winger_id = auth.uid())
+    )
+  );
+
+create policy "participants can update own messages"
+  on public.wing_discussion_messages for update
+  using (
+    exists (
+      select 1 from public.wing_discussions d
+      where d.id = discussion_id
+        and (d.dater_id = auth.uid() or d.winger_id = auth.uid())
+    )
+  );
+
+-- ── 3. Push-notification trigger ───────────────────────────────────────────────
+
+create or replace function public.notify_wing_discussion_message()
+returns trigger language plpgsql security definer as $$
+declare
+  _url text := current_setting('app.supabase_url', true);
+begin
+  if _url is null then return new; end if;
+  perform net.http_post(
+    url     := _url || '/functions/v1/notify-wing-discussion',
+    headers := '{"Content-Type":"application/json"}'::jsonb,
+    body    := jsonb_build_object(
+      'type',       'INSERT',
+      'table',      'wing_discussion_messages',
+      'schema',     'public',
+      'record',     row_to_json(new),
+      'old_record', null
+    )
+  );
+  return new;
+end;
+$$;
+
+create trigger on_wing_discussion_message_insert
+  after insert on public.wing_discussion_messages
+  for each row execute procedure public.notify_wing_discussion_message();
+
+-- ── 4. Add decision_id to get_discover_pool ────────────────────────────────────
+
+drop function if exists public.get_discover_pool(uuid, uuid, int, int, boolean);
+
+create function public.get_discover_pool(
+  viewer_id        uuid,
+  filter_winger_id uuid    default null,
+  page_size        int     default 20,
+  page_offset      int     default 0,
+  winger_only      boolean default false
+)
+returns table (
+  profile_id     uuid,
+  user_id        uuid,
+  chosen_name    text,
+  gender         public.gender,
+  age            int,
+  city           public.city,
+  bio            text,
+  dating_status  public.dating_status,
+  interests      public.interest[],
+  first_photo    text,
+  wing_note      text,
+  suggested_by   uuid,
+  suggester_name text,
+  decision_id    uuid
+)
+language sql security definer stable as $$
+  select
+    dp.id                                                         as profile_id,
+    dp.user_id,
+    p.chosen_name,
+    p.gender,
+    extract(year from age(p.date_of_birth))::int                  as age,
+    dp.city,
+    dp.bio,
+    dp.dating_status,
+    dp.interests,
+    (
+      select storage_url
+      from   public.profile_photos
+      where  dating_profile_id = dp.id
+        and  approved_at is not null
+      order  by display_order
+      limit  1
+    )                                                             as first_photo,
+    d.note                                                        as wing_note,
+    d.suggested_by,
+    s.chosen_name                                                 as suggester_name,
+    d.id                                                          as decision_id
+  from       public.dating_profiles  dp
+  join       public.profiles         p    on p.id   = dp.user_id
+  join       public.dating_profiles  vdp  on vdp.user_id = viewer_id
+  left join  public.decisions        d    on  d.actor_id     = viewer_id
+                                          and d.recipient_id = dp.user_id
+                                          and d.decision     is null
+                                          and d.suggested_by is not null
+  left join  public.profiles         s    on s.id = d.suggested_by
+  where
+    dp.is_active         = true
+    and dp.dating_status = 'open'
+    and dp.user_id       != viewer_id
+    and dp.city          = vdp.city
+    and (
+      vdp.interested_gender = '{}'::public.gender[]
+      or p.gender = any(vdp.interested_gender)
+    )
+    and extract(year from age(p.date_of_birth))::int >= vdp.age_from
+    and (
+      vdp.age_to is null
+      or extract(year from age(p.date_of_birth))::int <= vdp.age_to
+    )
+    and (
+      vdp.religious_preference is null
+      or dp.religion = vdp.religious_preference
+    )
+    and not exists (
+      select 1
+      from   public.decisions ex
+      where  ex.actor_id     = viewer_id
+        and  ex.recipient_id = dp.user_id
+        and  ex.decision     is not null
+    )
+    and not exists (
+      select 1
+      from   public.decisions ex
+      where  ex.actor_id     = dp.user_id
+        and  ex.recipient_id = viewer_id
+        and  ex.decision     = 'approved'
+    )
+    and (
+      filter_winger_id is null
+      or (d.suggested_by = filter_winger_id and d.decision is null)
+    )
+    and (
+      not winger_only
+      or d.id is not null
+    )
+  order by
+    (d.id is not null) desc,
+    dp.created_at desc
+  limit  page_size
+  offset page_offset
+$$;

--- a/types/database.ts
+++ b/types/database.ts
@@ -451,34 +451,158 @@ export type Database = {
         };
         Relationships: [];
       };
+      wing_discussion_messages: {
+        Row: {
+          body: string;
+          created_at: string;
+          discussion_id: string;
+          id: string;
+          is_read: boolean;
+          sender_id: string;
+        };
+        Insert: {
+          body: string;
+          created_at?: string;
+          discussion_id: string;
+          id?: string;
+          is_read?: boolean;
+          sender_id: string;
+        };
+        Update: {
+          body?: string;
+          created_at?: string;
+          discussion_id?: string;
+          id?: string;
+          is_read?: boolean;
+          sender_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'wing_discussion_messages_discussion_id_fkey';
+            columns: ['discussion_id'];
+            isOneToOne: false;
+            referencedRelation: 'wing_discussions';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'wing_discussion_messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      wing_discussions: {
+        Row: {
+          created_at: string;
+          dater_id: string;
+          decision_id: string;
+          id: string;
+          suggested_profile_id: string;
+          winger_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          dater_id: string;
+          decision_id: string;
+          id?: string;
+          suggested_profile_id: string;
+          winger_id: string;
+        };
+        Update: {
+          created_at?: string;
+          dater_id?: string;
+          decision_id?: string;
+          id?: string;
+          suggested_profile_id?: string;
+          winger_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'wing_discussions_dater_id_fkey';
+            columns: ['dater_id'];
+            isOneToOne: false;
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'wing_discussions_decision_id_fkey';
+            columns: ['decision_id'];
+            isOneToOne: true;
+            referencedRelation: 'decisions';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'wing_discussions_suggested_profile_id_fkey';
+            columns: ['suggested_profile_id'];
+            isOneToOne: false;
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'wing_discussions_winger_id_fkey';
+            columns: ['winger_id'];
+            isOneToOne: false;
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
     };
     Views: {
       [_ in never]: never;
     };
     Functions: {
-      get_discover_pool: {
-        Args: {
-          filter_winger_id?: string;
-          page_offset?: number;
-          page_size?: number;
-          viewer_id: string;
-        };
-        Returns: {
-          age: number;
-          bio: string;
-          chosen_name: string;
-          city: Database['public']['Enums']['city'];
-          dating_status: Database['public']['Enums']['dating_status'];
-          first_photo: string;
-          gender: Database['public']['Enums']['gender'];
-          interests: Database['public']['Enums']['interest'][];
-          profile_id: string;
-          suggested_by: string;
-          suggester_name: string;
-          user_id: string;
-          wing_note: string;
-        }[];
-      };
+      get_discover_pool:
+        | {
+            Args: {
+              filter_winger_id?: string;
+              page_offset?: number;
+              page_size?: number;
+              viewer_id: string;
+            };
+            Returns: {
+              age: number;
+              bio: string;
+              chosen_name: string;
+              city: Database['public']['Enums']['city'];
+              dating_status: Database['public']['Enums']['dating_status'];
+              first_photo: string;
+              gender: Database['public']['Enums']['gender'];
+              interests: Database['public']['Enums']['interest'][];
+              profile_id: string;
+              suggested_by: string;
+              suggester_name: string;
+              user_id: string;
+              wing_note: string;
+            }[];
+          }
+        | {
+            Args: {
+              filter_winger_id?: string;
+              page_offset?: number;
+              page_size?: number;
+              viewer_id: string;
+              winger_only?: boolean;
+            };
+            Returns: {
+              age: number;
+              bio: string;
+              chosen_name: string;
+              city: Database['public']['Enums']['city'];
+              dating_status: Database['public']['Enums']['dating_status'];
+              decision_id: string;
+              first_photo: string;
+              gender: Database['public']['Enums']['gender'];
+              interests: Database['public']['Enums']['interest'][];
+              profile_id: string;
+              suggested_by: string;
+              suggester_name: string;
+              user_id: string;
+              wing_note: string;
+            }[];
+          };
       get_likes_you_count: { Args: { viewer_id: string }; Returns: number };
       get_likes_you_pool: {
         Args: { page_offset?: number; page_size?: number; viewer_id: string };


### PR DESCRIPTION
## Summary
- Adds per-suggestion chat threads between a dater and their wingperson so they can discuss a suggested profile before the dater decides
- New `wing_discussions` + `wing_discussion_messages` tables with RLS and real-time push notifications
- `get_discover_pool` RPC now returns `decision_id` for winger-suggested cards
- Discover "For You" cards show a "Discuss" button + unread badge on the winger note section
- Wingpeople roster shows a "Discussions" section for both daters and wingers
- Fixtures seed 5 suggestion-only profiles (not in Likes You pool) for local dev

## Test plan
- [ ] Dater opens a winger-suggested card → taps "Discuss" → sheet opens → send a message
- [ ] Winger opens Wingpeople → sees "Discussions" section → taps thread → send a reply
- [ ] Dater receives push notification on winger's reply (and vice versa)
- [ ] Unread badge appears on discover card after winger sends a message; clears after opening thread
- [ ] Thread persists after dater swipes on the profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)