### PR TITLE
chore: remove interests section

### DIFF
--- a/app/(dater-tabs)/discover.tsx
+++ b/app/(dater-tabs)/discover.tsx
@@ -21,7 +21,6 @@ import { updateDatingProfile, useProfileData } from '@/queries/profiles';
 import { LargeHeader } from '@/components/ui/LargeHeader';
 import { TextTabBar } from '@/components/ui/TextTabBar';
 import { PhotoRect } from '@/components/ui/PhotoRect';
-import { Pill } from '@/components/ui/Pill';
 import { PurpleButton } from '@/components/ui/PurpleButton';
 import { WingStack } from '@/components/ui/WingStack';
 import { colors } from '@/constants/theme';
@@ -134,13 +133,6 @@ function CardView({ card }: { card: DiscoverCard }) {
         </Text>
         <Text className="text-sm text-fg-muted mt-1 mb-3">{card.city}</Text>
         {card.wing_note != null && <WingNoteSection card={card} />}
-        {card.interests.length > 0 && (
-          <View className="flex-row flex-wrap gap-2 mb-4">
-            {card.interests.map((interest) => (
-              <Pill key={interest} label={interest} />
-            ))}
-          </View>
-        )}
         {card.bio != null && (
           <Text className="text-sm text-fg-muted" style={{ lineHeight: 22 }}>
             {card.bio}

--- a/app/(dater-tabs)/profile/edit.tsx
+++ b/app/(dater-tabs)/profile/edit.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '@/context/auth';
 import { updateDatingProfile, useProfileData } from '@/queries/profiles';
 import type { OwnDatingProfile } from '@/queries/profiles';
 import type { Database } from '@/types/database';
-import { CITIES, GENDERS, RELIGIONS, INTERESTS } from '@/constants/enums';
+import { CITIES, GENDERS, RELIGIONS } from '@/constants/enums';
 import { View, Text, TextInput, ScrollView, SafeAreaView, Pressable } from '@/lib/tw';
 import { cn } from '@/lib/cn';
 
@@ -20,8 +20,6 @@ import { PurpleButton } from '@/components/ui/PurpleButton';
 type Gender = Database['public']['Enums']['gender'];
 type Religion = Database['public']['Enums']['religion'];
 type City = Database['public']['Enums']['city'];
-type Interest = Database['public']['Enums']['interest'];
-
 type FormValues = {
   bio: string;
   city: City | null;
@@ -30,7 +28,6 @@ type FormValues = {
   interestedGender: Gender[];
   religion: Religion | null;
   religiousPref: Religion | null;
-  interests: Interest[];
 };
 
 const RELIGIOUS_PREFS: { value: Religion | null; label: string }[] = [
@@ -151,7 +148,6 @@ function EditProfileForm({
       interestedGender: data.interested_gender as Gender[],
       religion: data.religion as Religion | null,
       religiousPref: (data.religious_preference as Religion | null) ?? null,
-      interests: data.interests as Interest[],
     },
   });
 
@@ -179,7 +175,6 @@ function EditProfileForm({
       interested_gender: values.interestedGender,
       religion: values.religion,
       religious_preference: values.religiousPref,
-      interests: values.interests,
     });
 
     if (error) {
@@ -345,20 +340,6 @@ function EditProfileForm({
                   );
                 })}
               </View>
-            )}
-          />
-
-          {/* Interests */}
-          <SectionLabel label="Interests" />
-          <Controller
-            control={control}
-            name="interests"
-            render={({ field }) => (
-              <MultiPickerRow<Interest>
-                options={INTERESTS}
-                values={field.value}
-                onChange={field.onChange}
-              />
             )}
           />
 

--- a/app/(dater-tabs)/profile/wingpeople/wingswipe.tsx
+++ b/app/(dater-tabs)/profile/wingpeople/wingswipe.tsx
@@ -9,7 +9,6 @@ import { useWingSwipe } from '@/hooks/use-wing-swipe';
 import { View, Text, Pressable, ScrollView, TextInput, SafeAreaView } from '@/lib/tw';
 import { NavHeader } from '@/components/ui/NavHeader';
 import { PhotoRect } from '@/components/ui/PhotoRect';
-import { Pill } from '@/components/ui/Pill';
 import { PurpleButton } from '@/components/ui/PurpleButton';
 import { useDaterContext } from '@/queries/profiles';
 import { useWingPool } from '@/queries/discover';
@@ -40,13 +39,6 @@ function WingCardView({ card }: WingCardViewProps) {
           {card.chosen_name}, {card.age}
         </Text>
         <Text className="text-sm text-fg-muted mt-1 mb-3">{card.city}</Text>
-        {card.interests.length > 0 && (
-          <View className="flex-row flex-wrap gap-2 mb-4">
-            {card.interests.map((interest) => (
-              <Pill key={interest} label={interest} />
-            ))}
-          </View>
-        )}
         {card.bio != null && (
           <Text className="text-sm text-fg-muted leading-[22px]">{card.bio}</Text>
         )}

--- a/components/profile/AboutMeTab.tsx
+++ b/components/profile/AboutMeTab.tsx
@@ -9,7 +9,6 @@ import { colors } from '@/constants/theme';
 import type { OwnDatingProfile } from '@/queries/profiles';
 import { updateDatingProfile } from '@/queries/profiles';
 
-import { Pill } from '@/components/ui/Pill';
 import { PurpleButton } from '@/components/ui/PurpleButton';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 
@@ -148,19 +147,6 @@ export function AboutMeTab({ form, data, userId }: Props) {
               </View>
             </>
           ) : null}
-
-          {data.interests.length > 0 && (
-            <>
-              <Text className="text-xs font-bold text-fg-subtle uppercase tracking-[0.6px] mt-5 mb-2">
-                Interests
-              </Text>
-              <View className="flex-row flex-wrap gap-2">
-                {data.interests.map((interest) => (
-                  <Pill key={interest} label={interest} />
-                ))}
-              </View>
-            </>
-          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary
- Remove interests pills from discover cards, wingswipe cards, own profile About Me tab, and the edit profile form
- Clean up unused `Pill` imports and `Interest` type/form field references

## Test plan
- [ ] Own profile About Me tab no longer shows interests section
- [ ] Edit Profile screen no longer shows interests picker
- [ ] Discover cards no longer show interest pills
- [ ] Wingswipe cards no longer show interest pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)