### PR TITLE
Fix message input hidden behind keyboard

### DIFF
--- a/app/(tabs)/messages/[matchId].tsx
+++ b/app/(tabs)/messages/[matchId].tsx
@@ -1,7 +1,9 @@
 import React, { useRef, useState } from 'react';
-import { FlatList, KeyboardAvoidingView, Platform, StyleSheet } from 'react-native';
+import { FlatList, Platform, StyleSheet } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Controller, useForm } from 'react-hook-form';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import Svg, { Path } from 'react-native-svg';
 
 import { useAuth } from '@/context/auth';
@@ -185,6 +187,7 @@ type ChatBodyProps = {
 function ChatBody({ matchId, userId, otherUserId, otherName }: ChatBodyProps) {
   const { messages, send } = useMessages(matchId);
   const { isOtherTyping, notifyTyping } = useTyping(otherUserId, userId);
+  const tabBarHeight = useBottomTabBarHeight();
   const listRef = useRef<FlatList>(null);
 
   const {
@@ -213,7 +216,7 @@ function ChatBody({ matchId, userId, otherUserId, otherName }: ChatBodyProps) {
     <KeyboardAvoidingView
       style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      keyboardVerticalOffset={0}
+      keyboardVerticalOffset={tabBarHeight}
     >
       <FlatList
         ref={listRef}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import 'react-native-url-polyfill/auto';
 import 'react-native-reanimated';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { Stack, router, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { Toaster } from 'sonner-native';
@@ -124,15 +125,17 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-            <AppShell />
-            <Toaster position="bottom-center" richColors />
-            <StatusBar style="auto" />
-          </ThemeProvider>
-        </AuthProvider>
-      </QueryClientProvider>
+      <KeyboardProvider>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+              <AppShell />
+              <Toaster position="bottom-center" richColors />
+              <StatusBar style="auto" />
+            </ThemeProvider>
+          </AuthProvider>
+        </QueryClientProvider>
+      </KeyboardProvider>
     </GestureHandlerRootView>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "react-native": "0.81.5",
         "react-native-css": "^3.0.4",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-keyboard-controller": "1.18.5",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -14895,6 +14896,20 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-keyboard-controller": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.5.tgz",
+      "integrity": "sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-native": "0.81.5",
     "react-native-css": "^3.0.4",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-keyboard-controller": "1.18.5",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",


### PR DESCRIPTION
## Summary
- Swap RN's `KeyboardAvoidingView` for the one from `react-native-keyboard-controller` on the chat screen — tracks the keyboard frame on the UI thread so the composer sticks during the open animation
- Wrap the app in `<KeyboardProvider>` in the root layout
- Pass `useBottomTabBarHeight()` as the offset so the input clears the bottom tab bar

Closes #71

> **Note:** `react-native-keyboard-controller` ships native code, so this needs a dev-client rebuild (`npm run build:dev-sim` / `build:device`) — OTA won't pick it up.

## Test plan
- [ ] Open a match thread, tap the composer — input bar stays visible above the keyboard
- [ ] Send a message — list scrolls to bottom, no jitter
- [ ] Background → foreground while keyboard is open — composer position is preserved
- [ ] Android: composer behavior is correct (height behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)