### PR TITLE
feat: shared settings screen accessible from both modes

### DIFF
--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -62,7 +62,7 @@ function SettingsButton() {
   const router = useRouter();
   return (
     <Pressable
-      onPress={() => router.push('/(tabs)/profile/settings' as any)}
+      onPress={() => router.push('/settings' as any)}
       className="flex-row items-center"
       style={{ gap: 6, paddingVertical: 6, paddingHorizontal: 10 }}
       hitSlop={8}

--- a/app/(winger-tabs)/me.tsx
+++ b/app/(winger-tabs)/me.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import { toast } from 'sonner-native';
 import { useQueryClient } from '@tanstack/react-query';
+import { Ionicons } from '@expo/vector-icons';
 
 import { useAuth } from '@/context/auth';
 import { View, Text, Pressable, ScrollView, SafeAreaView } from '@/lib/tw';
@@ -51,12 +52,11 @@ function MeContent() {
           Me
         </Text>
         <Pressable
-          onPress={handleSwitchToDater}
-          className="px-3 py-1.5 rounded-full bg-surface"
-          style={{ borderWidth: 1, borderColor: 'rgba(31,27,22,0.10)' }}
-          hitSlop={6}
+          onPress={() => router.push('/settings' as any)}
+          hitSlop={8}
+          style={{ padding: 6 }}
         >
-          <Text className="text-xs font-semibold text-ink-mid">Switch to dater mode</Text>
+          <Ionicons name="settings-outline" size={22} color="#4A4338" />
         </Pressable>
       </View>
 
@@ -73,15 +73,6 @@ function MeContent() {
           </Text>
           <Text className="text-sm mt-0.5 text-ink-dim">{subtitle}</Text>
         </View>
-        <Pressable
-          onPress={() => router.push('/(tabs)/profile/settings' as any)}
-          hitSlop={8}
-          className="px-2 py-2"
-        >
-          <Text className="text-ink-mid" style={{ fontSize: 18 }}>
-            ⚙
-          </Text>
-        </Pressable>
       </View>
 
       <View className="px-4">
@@ -121,7 +112,7 @@ function MeContent() {
       </Text>
       <View className="px-4" style={{ gap: 8 }}>
         <Pressable
-          onPress={() => router.push('/(tabs)/profile/settings' as any)}
+          onPress={() => router.push('/settings' as any)}
           className="bg-white rounded-xl px-3.5 py-3 flex-row items-center"
           style={{ borderWidth: 1, borderColor: 'rgba(31,27,22,0.06)', gap: 10 }}
         >

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -107,6 +107,7 @@ function AppShell() {
       <Stack.Screen name="(auth)" options={{ headerShown: false }} />
       <Stack.Screen name="(onboarding)" options={{ headerShown: false }} />
       <Stack.Screen name="invite" options={{ headerShown: false }} />
+      <Stack.Screen name="settings" options={{ headerShown: false }} />
     </Stack>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -87,6 +87,7 @@ function AppShell() {
   useEffect(() => {
     if (loading) return;
     if (currentGroup === targetGroup) return;
+    if (currentGroup === 'settings') return;
     const path =
       targetGroup === '(auth)'
         ? '/(auth)/login'

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,205 @@
+import { useRouter } from 'expo-router';
+import { toast } from 'sonner-native';
+import { StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useAuth } from '@/context/auth';
+import {
+  useGetApiProfilesMeSuspense,
+  useGetApiDatingProfilesMeSuspense,
+} from '@/lib/api/generated/profiles/profiles';
+import { useGetApiWingpeopleSuspense } from '@/lib/api/generated/contacts/contacts';
+import { View, Text, ScrollView, Pressable, SafeAreaView } from '@/lib/tw';
+import ScreenSuspense from '@/components/ui/ScreenSuspense';
+
+const INK = '#1F1B16';
+const INK3 = '#8B8170';
+const LINE = 'rgba(31,27,22,0.10)';
+const DANGER = '#A33';
+
+function SectionLabel({ children }: { children: string }) {
+  if (!children) return <View style={{ height: 8 }} />;
+  return (
+    <Text
+      className="text-ink-dim"
+      style={{
+        fontSize: 11,
+        letterSpacing: 1.2,
+        textTransform: 'uppercase',
+        fontWeight: '600',
+        paddingHorizontal: 24,
+        paddingTop: 18,
+        paddingBottom: 8,
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+type RowProps = {
+  label: string;
+  detail?: string;
+  danger?: boolean;
+  last?: boolean;
+  onPress?: () => void;
+};
+
+function Row({ label, detail, danger, last, onPress }: RowProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center"
+      style={{
+        minHeight: 50,
+        paddingHorizontal: 16,
+        borderBottomWidth: last ? 0 : StyleSheet.hairlineWidth,
+        borderBottomColor: LINE,
+      }}
+    >
+      <Text
+        style={{
+          flex: 1,
+          fontSize: 15,
+          fontWeight: '500',
+          color: danger ? DANGER : INK,
+        }}
+      >
+        {label}
+      </Text>
+      {detail ? (
+        <Text className="text-ink-dim" style={{ fontSize: 14, marginRight: 8 }}>
+          {detail}
+        </Text>
+      ) : null}
+      {!danger ? <Ionicons name="chevron-forward" size={14} color={INK3} /> : null}
+    </Pressable>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <View style={{ marginBottom: 22 }}>
+      <SectionLabel>{title}</SectionLabel>
+      <View
+        className="bg-surface"
+        style={{
+          borderRadius: 18,
+          marginHorizontal: 16,
+          overflow: 'hidden',
+          borderWidth: 1,
+          borderColor: LINE,
+        }}
+      >
+        {children}
+      </View>
+    </View>
+  );
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  open: 'Open',
+  break: 'On a break',
+  winging: 'Winging only',
+};
+
+function SettingsScreenInner() {
+  const router = useRouter();
+  const { signOut } = useAuth();
+
+  const { data: profile } = useGetApiProfilesMeSuspense();
+  const { data: datingProfile } = useGetApiDatingProfilesMeSuspense();
+  const { data: wingpeopleData } = useGetApiWingpeopleSuspense();
+
+  const wingCount = wingpeopleData.wingpeople.length;
+  const phoneDetail = profile?.phoneNumber ?? undefined;
+  const statusDetail = datingProfile?.datingStatus
+    ? STATUS_LABEL[datingProfile.datingStatus]
+    : undefined;
+
+  const handleLogOut = async () => {
+    const { error } = await signOut();
+    if (error) toast.error('Could not log out. Please try again.');
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-canvas" edges={['top']}>
+      <View
+        className="flex-row items-center"
+        style={{ paddingHorizontal: 12, paddingTop: 8, paddingBottom: 8, gap: 4 }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          style={{ padding: 8, marginLeft: -4 }}
+        >
+          <Ionicons name="chevron-back" size={22} color={INK} />
+        </Pressable>
+        <Text className="font-serif text-ink" style={{ fontSize: 26, letterSpacing: -0.4 }}>
+          Settings
+        </Text>
+      </View>
+
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingTop: 4, paddingBottom: 100 }}
+      >
+        <Section title="Account">
+          <Row label="Phone" detail={phoneDetail} />
+          <Row label="Connected accounts" detail="Apple" />
+          <Row label="Dating status" detail={statusDetail} last />
+        </Section>
+
+        <Section title="Wingpeople">
+          <Row label="Who can suggest profiles" detail="Wingpeople" />
+          <Row
+            label="Manage wingpeople"
+            detail={wingCount === 1 ? '1 active' : `${wingCount} active`}
+            onPress={() => router.push('/(tabs)/profile/wingpeople' as any)}
+            last
+          />
+        </Section>
+
+        <Section title="Notifications">
+          <Row label="New matches" detail="On" />
+          <Row label="Messages" detail="On" />
+          <Row label="Wing suggestions" detail="On" />
+          <Row label="Quiet hours" detail="10pm — 8am" last />
+        </Section>
+
+        <Section title="Privacy & legal">
+          <Row label="Block list" />
+          <Row label="Data & permissions" />
+          <Row label="Terms" />
+          <Row label="Privacy policy" last />
+        </Section>
+
+        <Section title="">
+          <Row label="Take a break from dating" />
+          <Row label="Log out" onPress={handleLogOut} />
+          <Row label="Delete account" danger last />
+        </Section>
+
+        <Text
+          className="text-ink-mid"
+          style={{
+            opacity: 0.5,
+            fontSize: 11,
+            textAlign: 'center',
+            marginTop: 4,
+          }}
+        >
+          Pear · v0
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+export default function SettingsScreen() {
+  return (
+    <ScreenSuspense>
+      <SettingsScreenInner />
+    </ScreenSuspense>
+  );
+}


### PR DESCRIPTION
## Summary
- Removes the \"Switch to dater mode\" button from the winger Me tab header
- Adds a settings icon (⚙) to the top-right of the winger Me header
- Creates a top-level `/settings` route registered in the root Stack — renders on top of whichever tab group is active, making it truly mode-agnostic
- Updates both dater (profile tab) and winger (Me tab) to navigate to the shared `/settings` route

## Test plan
- [ ] In winger mode: tap settings icon in top-right of Me tab — Settings screen opens correctly
- [ ] In winger mode: tap \"Account & notifications\" row — same Settings screen opens
- [ ] In dater mode: tap Settings button in Profile tab header — same Settings screen opens
- [ ] Back button on Settings screen returns to the correct mode in both cases
- [ ] Switching modes does not affect the Settings screen content

🤖 Generated with [Claude Code](https://claude.com/claude-code)