### PR TITLE
Winger Me tab redesign + interactive dating status picker

### DIFF
--- a/app/(winger-tabs)/me.tsx
+++ b/app/(winger-tabs)/me.tsx
@@ -1,52 +1,26 @@
 import { useRouter } from 'expo-router';
-import { toast } from 'sonner-native';
-import { useQueryClient } from '@tanstack/react-query';
 import { Ionicons } from '@expo/vector-icons';
 
 import { useAuth } from '@/context/auth';
-import { View, Text, Pressable, ScrollView, SafeAreaView } from '@/lib/tw';
+import { View, Text, Pressable, SafeAreaView } from '@/lib/tw';
 import { AvatarPicker } from '@/components/ui/AvatarPicker';
-import { Sprout } from '@/components/ui/Sprout';
 import ScreenSuspense from '@/components/ui/ScreenSuspense';
-import {
-  getGetApiDatingProfilesMeQueryKey,
-  getGetApiProfilesMeQueryKey,
-  patchApiDatingProfilesMe,
-  patchApiProfilesMe,
-  useGetApiDatingProfilesMeSuspense,
-  useGetApiProfilesMeSuspense,
-} from '@/lib/api/generated/profiles/profiles';
+import { useGetApiProfilesMeSuspense } from '@/lib/api/generated/profiles/profiles';
 import { useGetApiWingpeopleSuspense } from '@/lib/api/generated/contacts/contacts';
 
 function MeContent() {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const { userId } = useAuth();
 
   const { data: profile } = useGetApiProfilesMeSuspense();
-  const { data: datingProfile } = useGetApiDatingProfilesMeSuspense();
   const { data: wingpeopleData } = useGetApiWingpeopleSuspense();
 
   const wingingForCount = wingpeopleData.wingingFor.length;
-
-  const handleSwitchToDater = async () => {
-    try {
-      if (profile?.role === 'winger') {
-        await patchApiProfilesMe({ role: 'dater' });
-      } else if (datingProfile?.datingStatus === 'winging') {
-        await patchApiDatingProfilesMe({ datingStatus: 'open' });
-      }
-      queryClient.invalidateQueries({ queryKey: getGetApiProfilesMeQueryKey() });
-      queryClient.invalidateQueries({ queryKey: getGetApiDatingProfilesMeQueryKey() });
-    } catch {
-      toast.error("Couldn't switch profile. Try again.");
-    }
-  };
-
   const subtitle = wingingForCount > 0 ? `Winging for ${wingingForCount}` : 'Winger';
 
   return (
-    <ScrollView contentContainerClassName="pb-32">
+    <>
+      {/* ── Header ──────────────────────────────────────────────────────────── */}
       <View className="px-4 pt-2 pb-1 flex-row items-center justify-between">
         <Text className="font-serif text-ink" style={{ fontSize: 28, letterSpacing: -0.5 }}>
           Me
@@ -60,29 +34,34 @@ function MeContent() {
         </Pressable>
       </View>
 
-      <View className="px-4 pt-3 pb-4 flex-row items-center" style={{ gap: 14 }}>
-        <AvatarPicker
-          name={profile?.chosenName ?? ''}
-          avatarUrl={profile?.avatarUrl ?? null}
-          size={64}
-          userId={userId}
-        />
-        <View style={{ flex: 1 }}>
-          <Text className="font-serif text-ink" style={{ fontSize: 22, letterSpacing: -0.4 }}>
+      {/* ── Centered content ────────────────────────────────────────────────── */}
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: 16,
+          gap: 24,
+        }}
+      >
+        {/* Avatar + name + status */}
+        <View style={{ alignItems: 'center', gap: 10 }}>
+          <AvatarPicker
+            name={profile?.chosenName ?? ''}
+            avatarUrl={profile?.avatarUrl ?? null}
+            size={120}
+            userId={userId}
+          />
+          <Text className="font-serif text-ink" style={{ fontSize: 28, letterSpacing: -0.4 }}>
             {profile?.chosenName ?? 'Winger'}
           </Text>
-          <Text className="text-sm mt-0.5 text-ink-dim">{subtitle}</Text>
+          <Text className="text-ink-dim" style={{ fontSize: 15 }}>
+            {subtitle}
+          </Text>
         </View>
-      </View>
 
-      <View className="px-4">
-        <View
-          className="bg-ink"
-          style={{
-            borderRadius: 20,
-            padding: 18,
-          }}
-        >
+        {/* Wing card */}
+        <View className="bg-ink" style={{ borderRadius: 20, padding: 18, width: '100%' }}>
           <Text
             className="text-surface"
             style={{
@@ -106,40 +85,7 @@ function MeContent() {
           </Text>
         </View>
       </View>
-
-      <Text className="text-xs font-semibold uppercase tracking-[0.6px] px-5 pt-6 pb-2 text-fg-muted">
-        Settings
-      </Text>
-      <View className="px-4" style={{ gap: 8 }}>
-        <Pressable
-          onPress={() => router.push('/settings' as any)}
-          className="bg-white rounded-xl px-3.5 py-3 flex-row items-center"
-          style={{ borderWidth: 1, borderColor: 'rgba(31,27,22,0.06)', gap: 10 }}
-        >
-          <Text className="flex-1 text-sm text-ink">Account & notifications</Text>
-          <Text className="text-ink-dim">›</Text>
-        </Pressable>
-      </View>
-
-      {profile?.role !== 'winger' && datingProfile?.datingStatus === 'winging' ? (
-        <View className="px-4 mt-6">
-          <Sprout block variant="secondary" onPress={handleSwitchToDater}>
-            Resume dating
-          </Sprout>
-        </View>
-      ) : null}
-
-      {profile?.role === 'winger' ? (
-        <View className="px-4 mt-6">
-          <Text className="text-sm mb-2 text-ink-dim">
-            Want to date too? Spin up your own profile.
-          </Text>
-          <Sprout block variant="secondary" onPress={handleSwitchToDater}>
-            Start dating
-          </Sprout>
-        </View>
-      ) : null}
-    </ScrollView>
+    </>
   );
 }
 

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,12 +1,18 @@
+import { Modal, StyleSheet } from 'react-native';
+import { useState } from 'react';
 import { useRouter } from 'expo-router';
 import { toast } from 'sonner-native';
-import { StyleSheet } from 'react-native';
+import { useQueryClient } from '@tanstack/react-query';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useAuth } from '@/context/auth';
 import {
   useGetApiProfilesMeSuspense,
   useGetApiDatingProfilesMeSuspense,
+  patchApiDatingProfilesMe,
+  getGetApiDatingProfilesMeQueryKey,
+  getGetApiProfilesMeQueryKey,
 } from '@/lib/api/generated/profiles/profiles';
 import { useGetApiWingpeopleSuspense } from '@/lib/api/generated/contacts/contacts';
 import { View, Text, ScrollView, Pressable, SafeAreaView } from '@/lib/tw';
@@ -16,6 +22,18 @@ const INK = '#1F1B16';
 const INK3 = '#8B8170';
 const LINE = 'rgba(31,27,22,0.10)';
 const DANGER = '#A33';
+
+const STATUS_OPTIONS = [
+  { label: 'Open to Dating', value: 'open' as const },
+  { label: 'Taking a Break', value: 'break' as const },
+  { label: 'Just Winging', value: 'winging' as const },
+];
+
+const STATUS_LABEL: Record<string, string> = {
+  open: 'Open to Dating',
+  break: 'Taking a Break',
+  winging: 'Just Winging',
+};
 
 function SectionLabel({ children }: { children: string }) {
   if (!children) return <View style={{ height: 8 }} />;
@@ -97,25 +115,43 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
-const STATUS_LABEL: Record<string, string> = {
-  open: 'Open',
-  break: 'On a break',
-  winging: 'Winging only',
-};
-
 function SettingsScreenInner() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { signOut } = useAuth();
+  const insets = useSafeAreaInsets();
 
   const { data: profile } = useGetApiProfilesMeSuspense();
   const { data: datingProfile } = useGetApiDatingProfilesMeSuspense();
   const { data: wingpeopleData } = useGetApiWingpeopleSuspense();
 
+  const [statusPickerVisible, setStatusPickerVisible] = useState(false);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+
   const wingCount = wingpeopleData.wingpeople.length;
   const phoneDetail = profile?.phoneNumber ?? undefined;
-  const statusDetail = datingProfile?.datingStatus
-    ? STATUS_LABEL[datingProfile.datingStatus]
-    : undefined;
+
+  const currentStatus =
+    datingProfile?.datingStatus ?? (profile?.role === 'winger' ? 'winging' : undefined);
+  const statusDetail = currentStatus ? STATUS_LABEL[currentStatus] : undefined;
+
+  const handleSelectStatus = async (value: 'open' | 'break' | 'winging') => {
+    if (!datingProfile || value === datingProfile.datingStatus) {
+      setStatusPickerVisible(false);
+      return;
+    }
+    setUpdatingStatus(true);
+    try {
+      await patchApiDatingProfilesMe({ datingStatus: value });
+      queryClient.invalidateQueries({ queryKey: getGetApiDatingProfilesMeQueryKey() });
+      queryClient.invalidateQueries({ queryKey: getGetApiProfilesMeQueryKey() });
+    } catch {
+      toast.error("Couldn't update dating status. Try again.");
+    } finally {
+      setUpdatingStatus(false);
+      setStatusPickerVisible(false);
+    }
+  };
 
   const handleLogOut = async () => {
     const { error } = await signOut();
@@ -147,8 +183,87 @@ function SettingsScreenInner() {
         <Section title="Account">
           <Row label="Phone" detail={phoneDetail} />
           <Row label="Connected accounts" detail="Apple" />
-          <Row label="Dating status" detail={statusDetail} last />
+          <Row
+            label="Dating status"
+            detail={statusDetail}
+            onPress={datingProfile ? () => setStatusPickerVisible(true) : undefined}
+            last
+          />
         </Section>
+
+        {/* ── Dating Status Picker ─────────────────────────────────────────────── */}
+        <Modal
+          visible={statusPickerVisible}
+          animationType="slide"
+          transparent
+          onRequestClose={() => setStatusPickerVisible(false)}
+        >
+          <View style={{ flex: 1, backgroundColor: 'rgba(31,27,22,0.45)' }}>
+            <Pressable style={{ flex: 1 }} onPress={() => setStatusPickerVisible(false)} />
+            <View
+              style={{
+                backgroundColor: '#F5F1E8',
+                borderTopLeftRadius: 24,
+                borderTopRightRadius: 24,
+                paddingTop: 14,
+                paddingBottom: insets.bottom + 24,
+              }}
+            >
+              <View
+                style={{
+                  alignSelf: 'center',
+                  width: 40,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor: LINE,
+                  marginBottom: 18,
+                }}
+              />
+              <Text
+                style={{
+                  fontFamily: 'DMSerifDisplay_400Regular',
+                  fontSize: 22,
+                  letterSpacing: -0.3,
+                  color: INK,
+                  paddingHorizontal: 20,
+                  marginBottom: 14,
+                }}
+              >
+                Dating Status
+              </Text>
+              {STATUS_OPTIONS.map((opt) => {
+                const selected = currentStatus === opt.value;
+                return (
+                  <Pressable
+                    key={opt.value}
+                    onPress={() => !updatingStatus && handleSelectStatus(opt.value)}
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      paddingHorizontal: 20,
+                      paddingVertical: 16,
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderTopColor: LINE,
+                      opacity: updatingStatus ? 0.5 : 1,
+                    }}
+                  >
+                    <Text
+                      style={{
+                        flex: 1,
+                        fontSize: 16,
+                        fontWeight: selected ? '600' : '400',
+                        color: selected ? '#5A8C3A' : INK,
+                      }}
+                    >
+                      {opt.label}
+                    </Text>
+                    {selected ? <Ionicons name="checkmark" size={20} color="#5A8C3A" /> : null}
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+        </Modal>
 
         <Section title="Wingpeople">
           <Row label="Who can suggest profiles" detail="Wingpeople" />


### PR DESCRIPTION
## Summary
- Redesigned winger Me screen: centered layout with 120px avatar, name/subtitle, and wing card; removed mode-switching buttons and bottom settings row
- Added interactive dating status picker in Settings: tapping "Dating status" opens a modal bottom sheet to switch between Open to Dating, Taking a Break, and Just Winging
- Status change calls `patchApiDatingProfilesMe` and invalidates queries, automatically rerouting the user to the appropriate mode

## Test plan
- [ ] In winger mode, verify Me tab shows centered avatar (120px), name, "Winger" subtitle, and wing card with no extra buttons
- [ ] Settings icon in top-right of Me tab opens Settings screen
- [ ] In Settings, tap "Dating status" — modal bottom sheet appears with three options and a checkmark on the current selection
- [ ] Changing status from "Just Winging" → "Open to Dating" exits settings and routes to dater mode
- [ ] Changing status from dater mode → "Just Winging" routes to winger mode
- [ ] "Taking a Break" keeps dater mode UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)